### PR TITLE
Fix type violations to be more robust

### DIFF
--- a/aas_core3_0_testgen/generation.py
+++ b/aas_core3_0_testgen/generation.py
@@ -818,22 +818,24 @@ def _generate_type_violations(maximal_case: CaseMaximal) -> Iterator[CaseTypeVio
         # region Mutate
         type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-        # NOTE (mristin, 2023-03-13):
-        # If it is a primitive property or an enumeration, set it to a list. If it
-        # is not a primitive property, set it to an unexpected string.
-        #
-        # This way we are sure that we will have a type violation according to
-        # the schema.
+        if not isinstance(type_anno, intermediate.ListTypeAnnotation):
+            unexpected_instance, _ = preserialization.preserialize(
+                aas_types.Reference(
+                    type=aas_types.ReferenceTypes.EXTERNAL_REFERENCE,
+                    keys=[
+                        aas_types.Key(
+                            type=aas_types.KeyTypes.GLOBAL_REFERENCE,
+                            value="unexpected instance",
+                        )
+                    ],
+                )
+            )
 
-        maybe_primitive_type = intermediate.try_primitive_type(type_anno)
-
-        if maybe_primitive_type is not None or (
-            isinstance(type_anno, intermediate.OurTypeAnnotation)
-            and isinstance(type_anno.our_type, intermediate.Enumeration)
-        ):
             # fmt: off
             preserialized_instance.properties[prop.name] = (
-                preserialization.ListOfInstances(values=[])
+                preserialization.ListOfInstances(
+                    values=[unexpected_instance]
+                )
             )
             # fmt: on
         else:

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json
@@ -2,7 +2,17 @@
   "assetAdministrationShells": [
     {
       "administration": {
-        "creator": "Unexpected string value",
+        "creator": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ],
         "embeddedDataSpecifications": [
           {
             "dataSpecification": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/revision.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/revision.json
@@ -38,7 +38,17 @@
             }
           }
         ],
-        "revision": [],
+        "revision": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ],
         "templateId": "something_cb08d136",
         "version": "1230"
       },

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/templateId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/templateId.json
@@ -39,7 +39,17 @@
           }
         ],
         "revision": "0",
-        "templateId": [],
+        "templateId": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ],
         "version": "1230"
       },
       "assetInformation": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/version.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/version.json
@@ -40,7 +40,17 @@
         ],
         "revision": "0",
         "templateId": "something_cb08d136",
-        "version": []
+        "version": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ]
       },
       "assetInformation": {
         "assetKind": "NotApplicable",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/category.json
@@ -10,7 +10,17 @@
               "modelType": "MultiLanguageProperty"
             }
           ],
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json
@@ -55,7 +55,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "first": "Unexpected string value",
+          "first": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "idShort": "PiXO1wyHierj",
           "modelType": "AnnotatedRelationshipElement",
           "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/idShort.json
@@ -64,7 +64,17 @@
             ],
             "type": "ExternalReference"
           },
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "AnnotatedRelationshipElement",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json
@@ -72,7 +72,17 @@
               "valueType": "xs:long"
             }
           ],
-          "second": "Unexpected string value",
+          "second": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json
@@ -81,7 +81,17 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json
@@ -1,7 +1,17 @@
 {
   "assetAdministrationShells": [
     {
-      "administration": "Unexpected string value",
+      "administration": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "assetInformation": {
         "assetKind": "NotApplicable",
         "globalAssetId": "something_eea66fa1"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json
@@ -2,7 +2,17 @@
   "assetAdministrationShells": [
     {
       "administration": {},
-      "assetInformation": "Unexpected string value",
+      "assetInformation": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "category": "something_1dc62cea",
       "derivedFrom": {
         "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/category.json
@@ -6,7 +6,17 @@
         "assetKind": "NotApplicable",
         "globalAssetId": "something_eea66fa1"
       },
-      "category": [],
+      "category": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "derivedFrom": {
         "keys": [
           {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json
@@ -7,7 +7,17 @@
         "globalAssetId": "something_eea66fa1"
       },
       "category": "something_1dc62cea",
-      "derivedFrom": "Unexpected string value",
+      "derivedFrom": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "description": [
         {
           "language": "Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/id.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/id.json
@@ -60,7 +60,17 @@
           "name": "something_94548e46"
         }
       ],
-      "id": [],
+      "id": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "idShort": "PiXO1wyHierj",
       "modelType": "AssetAdministrationShell",
       "submodels": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/idShort.json
@@ -61,7 +61,17 @@
         }
       ],
       "id": "something_142922d6",
-      "idShort": [],
+      "idShort": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "modelType": "AssetAdministrationShell",
       "submodels": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/assetKind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/assetKind.json
@@ -2,7 +2,17 @@
   "assetAdministrationShells": [
     {
       "assetInformation": {
-        "assetKind": [],
+        "assetKind": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ],
         "assetType": "something_9f4c5692",
         "defaultThumbnail": {
           "path": "file:/M5/%bA:'%9c%6b%ed%00Y*/%4C=4h:d:"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/assetType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/assetType.json
@@ -3,7 +3,17 @@
     {
       "assetInformation": {
         "assetKind": "NotApplicable",
-        "assetType": [],
+        "assetType": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ],
         "defaultThumbnail": {
           "path": "file:/M5/%bA:'%9c%6b%ed%00Y*/%4C=4h:d:"
         },

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json
@@ -4,7 +4,17 @@
       "assetInformation": {
         "assetKind": "NotApplicable",
         "assetType": "something_9f4c5692",
-        "defaultThumbnail": "Unexpected string value",
+        "defaultThumbnail": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ],
         "globalAssetId": "something_c71f0c8f"
       },
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/globalAssetId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/globalAssetId.json
@@ -7,7 +7,17 @@
         "defaultThumbnail": {
           "path": "file:/M5/%bA:'%9c%6b%ed%00Y*/%4C=4h:d:"
         },
-        "globalAssetId": []
+        "globalAssetId": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ]
       },
       "id": "something_142922d6",
       "modelType": "AssetAdministrationShell"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/direction.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/direction.json
@@ -12,7 +12,17 @@
               "text": "something_be9deae0"
             }
           ],
-          "direction": [],
+          "direction": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "displayName": [
             {
               "language": "Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/idShort.json
@@ -51,7 +51,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "lastUpdate": "-3020-08-21T24:00:00.0Z",
           "maxInterval": "PT130S",
           "messageBroker": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/lastUpdate.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/lastUpdate.json
@@ -52,7 +52,17 @@
             }
           ],
           "idShort": "PiXO1wyHierj",
-          "lastUpdate": [],
+          "lastUpdate": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "maxInterval": "PT130S",
           "messageBroker": {
             "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/maxInterval.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/maxInterval.json
@@ -53,7 +53,17 @@
           ],
           "idShort": "PiXO1wyHierj",
           "lastUpdate": "-3020-08-21T24:00:00.0Z",
-          "maxInterval": [],
+          "maxInterval": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "messageBroker": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json
@@ -54,7 +54,17 @@
           "idShort": "PiXO1wyHierj",
           "lastUpdate": "-3020-08-21T24:00:00.0Z",
           "maxInterval": "PT130S",
-          "messageBroker": "Unexpected string value",
+          "messageBroker": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "messageTopic": "something_99f1a7ac",
           "minInterval": "-P1Y",
           "modelType": "BasicEventElement",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageTopic.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageTopic.json
@@ -63,7 +63,17 @@
             ],
             "type": "ModelReference"
           },
-          "messageTopic": [],
+          "messageTopic": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "minInterval": "-P1Y",
           "modelType": "BasicEventElement",
           "observed": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/minInterval.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/minInterval.json
@@ -64,7 +64,17 @@
             "type": "ModelReference"
           },
           "messageTopic": "something_99f1a7ac",
-          "minInterval": [],
+          "minInterval": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "BasicEventElement",
           "observed": {
             "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json
@@ -66,7 +66,17 @@
           "messageTopic": "something_99f1a7ac",
           "minInterval": "-P1Y",
           "modelType": "BasicEventElement",
-          "observed": "Unexpected string value",
+          "observed": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "qualifiers": [
             {
               "type": "something_500f973e",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json
@@ -81,7 +81,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "state": "off",
           "supplementalSemanticIds": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/state.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/state.json
@@ -90,7 +90,17 @@
             ],
             "type": "ExternalReference"
           },
-          "state": [],
+          "state": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
           "description": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/contentType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/contentType.json
@@ -6,7 +6,17 @@
       "submodelElements": [
         {
           "category": "VARIABLE",
-          "contentType": [],
+          "contentType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/idShort.json
@@ -51,7 +51,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "Blob",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json
@@ -59,7 +59,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/value.json
@@ -79,7 +79,17 @@
               "type": "ModelReference"
             }
           ],
-          "value": []
+          "value": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/idShort.json
@@ -50,7 +50,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "Capability",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json
@@ -58,7 +58,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json
@@ -1,7 +1,17 @@
 {
   "conceptDescriptions": [
     {
-      "administration": "Unexpected string value",
+      "administration": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "category": "something_07a45fb3",
       "description": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/category.json
@@ -2,7 +2,17 @@
   "conceptDescriptions": [
     {
       "administration": {},
-      "category": [],
+      "category": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "description": [
         {
           "language": "Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/id.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/id.json
@@ -47,7 +47,17 @@
           "name": "something_4b532e77"
         }
       ],
-      "id": [],
+      "id": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "idShort": "fiZ",
       "isCaseOf": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/idShort.json
@@ -48,7 +48,17 @@
         }
       ],
       "id": "something_8ccad77f",
-      "idShort": [],
+      "idShort": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "isCaseOf": [
         {
           "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/dataType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/dataType.json
@@ -17,7 +17,17 @@
             "type": "ExternalReference"
           },
           "dataSpecificationContent": {
-            "dataType": [],
+            "dataType": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "definition": [
               {
                 "language": "X-33DQI-g",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json
@@ -24,7 +24,17 @@
                 "text": "something_2ae95f9f"
               }
             ],
-            "levelType": "Unexpected string value",
+            "levelType": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "modelType": "DataSpecificationIec61360",
             "preferredName": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/sourceOfDefinition.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/sourceOfDefinition.json
@@ -47,7 +47,17 @@
                 "text": "something_65af8271"
               }
             ],
-            "sourceOfDefinition": [],
+            "sourceOfDefinition": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "symbol": "something_c13116d7",
             "unit": "something_a6bd9450",
             "unitId": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/symbol.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/symbol.json
@@ -48,7 +48,17 @@
               }
             ],
             "sourceOfDefinition": "something_1bd907c8",
-            "symbol": [],
+            "symbol": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "unit": "something_a6bd9450",
             "unitId": {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unit.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unit.json
@@ -49,7 +49,17 @@
             ],
             "sourceOfDefinition": "something_1bd907c8",
             "symbol": "something_c13116d7",
-            "unit": [],
+            "unit": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "unitId": {
               "keys": [
                 {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json
@@ -50,7 +50,17 @@
             "sourceOfDefinition": "something_1bd907c8",
             "symbol": "something_c13116d7",
             "unit": "something_a6bd9450",
-            "unitId": "Unexpected string value",
+            "unitId": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "value": "something_13759f45",
             "valueFormat": "something_f019e5a8"
           }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/value.json
@@ -59,7 +59,17 @@
               ],
               "type": "ModelReference"
             },
-            "value": [],
+            "value": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "valueFormat": "something_f019e5a8"
           }
         }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/valueFormat.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/valueFormat.json
@@ -60,7 +60,17 @@
               "type": "ModelReference"
             },
             "value": "something_13759f45",
-            "valueFormat": []
+            "valueFormat": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ]
           }
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json
@@ -7,7 +7,17 @@
       },
       "embeddedDataSpecifications": [
         {
-          "dataSpecification": "Unexpected string value",
+          "dataSpecification": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "dataSpecificationContent": {
             "modelType": "DataSpecificationIec61360",
             "preferredName": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecificationContent.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecificationContent.json
@@ -16,7 +16,17 @@
             ],
             "type": "ExternalReference"
           },
-          "dataSpecificationContent": "Unexpected string value"
+          "dataSpecificationContent": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ],
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/entityType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/entityType.json
@@ -45,7 +45,17 @@
               }
             }
           ],
-          "entityType": [],
+          "entityType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "extensions": [
             {
               "name": "something_aa1af8b3"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/idShort.json
@@ -51,7 +51,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "Entity",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json
@@ -59,7 +59,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "statements": [
             {
               "modelType": "Range",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/name.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/name.json
@@ -7,7 +7,17 @@
       },
       "extensions": [
         {
-          "name": [],
+          "name": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "refersTo": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json
@@ -19,7 +19,17 @@
               "type": "ModelReference"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/value.json
@@ -39,7 +39,17 @@
               "type": "ExternalReference"
             }
           ],
-          "value": [],
+          "value": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "valueType": "xs:unsignedShort"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/valueType.json
@@ -40,7 +40,17 @@
             }
           ],
           "value": "10233",
-          "valueType": []
+          "valueType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ],
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
           "description": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/contentType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/contentType.json
@@ -6,7 +6,17 @@
       "submodelElements": [
         {
           "category": "VARIABLE",
-          "contentType": [],
+          "contentType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/idShort.json
@@ -51,7 +51,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "File",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json
@@ -59,7 +59,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/value.json
@@ -79,7 +79,17 @@
               "type": "ModelReference"
             }
           ],
-          "value": []
+          "value": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Key/type.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Key/type.json
@@ -8,7 +8,17 @@
       "derivedFrom": {
         "keys": [
           {
-            "type": [],
+            "type": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "value": "urn:an-example08:f3f73640"
           }
         ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Key/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Key/value.json
@@ -9,7 +9,17 @@
         "keys": [
           {
             "type": "AssetAdministrationShell",
-            "value": []
+            "value": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ]
           }
         ],
         "type": "ModelReference"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringDefinitionTypeIec61360/language.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringDefinitionTypeIec61360/language.json
@@ -19,7 +19,17 @@
           "dataSpecificationContent": {
             "definition": [
               {
-                "language": [],
+                "language": [
+                  {
+                    "keys": [
+                      {
+                        "type": "GlobalReference",
+                        "value": "unexpected instance"
+                      }
+                    ],
+                    "type": "ExternalReference"
+                  }
+                ],
                 "text": "something_29357dd5"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringDefinitionTypeIec61360/text.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringDefinitionTypeIec61360/text.json
@@ -20,7 +20,17 @@
             "definition": [
               {
                 "language": "X-33DQI-g",
-                "text": []
+                "text": [
+                  {
+                    "keys": [
+                      {
+                        "type": "GlobalReference",
+                        "value": "unexpected instance"
+                      }
+                    ],
+                    "type": "ExternalReference"
+                  }
+                ]
               }
             ],
             "modelType": "DataSpecificationIec61360",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringNameType/language.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringNameType/language.json
@@ -7,7 +7,17 @@
       },
       "displayName": [
         {
-          "language": [],
+          "language": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "text": "something_09c304fd"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringNameType/text.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringNameType/text.json
@@ -8,7 +8,17 @@
       "displayName": [
         {
           "language": "en",
-          "text": []
+          "text": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ],
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringPreferredNameTypeIec61360/language.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringPreferredNameTypeIec61360/language.json
@@ -20,7 +20,17 @@
             "modelType": "DataSpecificationIec61360",
             "preferredName": [
               {
-                "language": [],
+                "language": [
+                  {
+                    "keys": [
+                      {
+                        "type": "GlobalReference",
+                        "value": "unexpected instance"
+                      }
+                    ],
+                    "type": "ExternalReference"
+                  }
+                ],
                 "text": "something_c98d9907"
               },
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringPreferredNameTypeIec61360/text.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringPreferredNameTypeIec61360/text.json
@@ -21,7 +21,17 @@
             "preferredName": [
               {
                 "language": "X-33DQI-g",
-                "text": []
+                "text": [
+                  {
+                    "keys": [
+                      {
+                        "type": "GlobalReference",
+                        "value": "unexpected instance"
+                      }
+                    ],
+                    "type": "ExternalReference"
+                  }
+                ]
               },
               {
                 "language": "en-UK",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringShortNameTypeIec61360/language.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringShortNameTypeIec61360/language.json
@@ -30,7 +30,17 @@
             ],
             "shortName": [
               {
-                "language": [],
+                "language": [
+                  {
+                    "keys": [
+                      {
+                        "type": "GlobalReference",
+                        "value": "unexpected instance"
+                      }
+                    ],
+                    "type": "ExternalReference"
+                  }
+                ],
                 "text": "something_75139f2c"
               }
             ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringShortNameTypeIec61360/text.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringShortNameTypeIec61360/text.json
@@ -31,7 +31,17 @@
             "shortName": [
               {
                 "language": "X-33DQI-g",
-                "text": []
+                "text": [
+                  {
+                    "keys": [
+                      {
+                        "type": "GlobalReference",
+                        "value": "unexpected instance"
+                      }
+                    ],
+                    "type": "ExternalReference"
+                  }
+                ]
               }
             ],
             "value": "something_13759f45"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringTextType/language.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringTextType/language.json
@@ -7,7 +7,17 @@
       },
       "description": [
         {
-          "language": [],
+          "language": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "text": "something_5340dd75"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringTextType/text.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LangStringTextType/text.json
@@ -8,7 +8,17 @@
       "description": [
         {
           "language": "de-CH",
-          "text": []
+          "text": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ],
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LevelType/max.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LevelType/max.json
@@ -18,7 +18,17 @@
           },
           "dataSpecificationContent": {
             "levelType": {
-              "max": [],
+              "max": [
+                {
+                  "keys": [
+                    {
+                      "type": "GlobalReference",
+                      "value": "unexpected instance"
+                    }
+                  ],
+                  "type": "ExternalReference"
+                }
+              ],
               "min": true,
               "nom": true,
               "typ": true

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LevelType/min.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LevelType/min.json
@@ -19,7 +19,17 @@
           "dataSpecificationContent": {
             "levelType": {
               "max": true,
-              "min": [],
+              "min": [
+                {
+                  "keys": [
+                    {
+                      "type": "GlobalReference",
+                      "value": "unexpected instance"
+                    }
+                  ],
+                  "type": "ExternalReference"
+                }
+              ],
               "nom": true,
               "typ": true
             },

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LevelType/nom.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LevelType/nom.json
@@ -20,7 +20,17 @@
             "levelType": {
               "max": true,
               "min": true,
-              "nom": [],
+              "nom": [
+                {
+                  "keys": [
+                    {
+                      "type": "GlobalReference",
+                      "value": "unexpected instance"
+                    }
+                  ],
+                  "type": "ExternalReference"
+                }
+              ],
               "typ": true
             },
             "modelType": "DataSpecificationIec61360",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LevelType/typ.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/LevelType/typ.json
@@ -21,7 +21,17 @@
               "max": true,
               "min": true,
               "nom": true,
-              "typ": []
+              "typ": [
+                {
+                  "keys": [
+                    {
+                      "type": "GlobalReference",
+                      "value": "unexpected instance"
+                    }
+                  ],
+                  "type": "ExternalReference"
+                }
+              ]
             },
             "modelType": "DataSpecificationIec61360",
             "preferredName": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/idShort.json
@@ -50,7 +50,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "MultiLanguageProperty",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json
@@ -58,7 +58,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json
@@ -84,7 +84,17 @@
               "text": "something_cd7e6587"
             }
           ],
-          "valueId": "Unexpected string value"
+          "valueId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/idShort.json
@@ -50,7 +50,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "inoutputVariables": [
             {
               "value": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json
@@ -98,7 +98,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/OperationVariable/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/OperationVariable/value.json
@@ -8,7 +8,17 @@
           "idShort": "something3fdd3eb4",
           "inputVariables": [
             {
-              "value": "Unexpected string value"
+              "value": [
+                {
+                  "keys": [
+                    {
+                      "type": "GlobalReference",
+                      "value": "unexpected instance"
+                    }
+                  ],
+                  "type": "ExternalReference"
+                }
+              ]
             }
           ],
           "modelType": "Operation"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/idShort.json
@@ -50,7 +50,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "Property",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json
@@ -58,7 +58,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/value.json
@@ -78,7 +78,17 @@
               "type": "ModelReference"
             }
           ],
-          "value": [],
+          "value": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "valueId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json
@@ -79,7 +79,17 @@
             }
           ],
           "value": "0061707",
-          "valueId": "Unexpected string value",
+          "valueId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "valueType": "xs:decimal"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueType.json
@@ -88,7 +88,17 @@
             ],
             "type": "ModelReference"
           },
-          "valueType": []
+          "valueType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/kind.json
@@ -6,7 +6,17 @@
       "modelType": "Submodel",
       "qualifiers": [
         {
-          "kind": [],
+          "kind": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json
@@ -7,7 +7,17 @@
       "qualifiers": [
         {
           "kind": "TemplateQualifier",
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/type.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/type.json
@@ -27,7 +27,17 @@
               "type": "ExternalReference"
             }
           ],
-          "type": [],
+          "type": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "value": "001",
           "valueId": {
             "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/value.json
@@ -28,7 +28,17 @@
             }
           ],
           "type": "something_5964ab43",
-          "value": [],
+          "value": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "valueId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json
@@ -29,7 +29,17 @@
           ],
           "type": "something_5964ab43",
           "value": "001",
-          "valueId": "Unexpected string value",
+          "valueId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "valueType": "xs:integer"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueType.json
@@ -38,7 +38,17 @@
             ],
             "type": "ModelReference"
           },
-          "valueType": []
+          "valueType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/idShort.json
@@ -50,7 +50,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "max": "1234.1234567890123456789012345678901234567890123456789012345678901234567890",
           "modelType": "Range",
           "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/max.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/max.json
@@ -51,7 +51,17 @@
             }
           ],
           "idShort": "PiXO1wyHierj",
-          "max": [],
+          "max": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "Range",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json
@@ -59,7 +59,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/valueType.json
@@ -79,7 +79,17 @@
               "type": "ModelReference"
             }
           ],
-          "valueType": []
+          "valueType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json
@@ -12,7 +12,17 @@
             "value": "urn:an-example08:f3f73640"
           }
         ],
-        "referredSemanticId": "Unexpected string value",
+        "referredSemanticId": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ],
         "type": "ModelReference"
       },
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/type.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/type.json
@@ -21,7 +21,17 @@
           ],
           "type": "ExternalReference"
         },
-        "type": []
+        "type": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ]
       },
       "id": "something_142922d6",
       "modelType": "AssetAdministrationShell"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/idShort.json
@@ -50,7 +50,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "ReferenceElement",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json
@@ -58,7 +58,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json
@@ -78,7 +78,17 @@
               "type": "ModelReference"
             }
           ],
-          "value": "Unexpected string value"
+          "value": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json
@@ -50,7 +50,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "first": "Unexpected string value",
+          "first": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "idShort": "PiXO1wyHierj",
           "modelType": "RelationshipElement",
           "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/idShort.json
@@ -59,7 +59,17 @@
             ],
             "type": "ExternalReference"
           },
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "RelationshipElement",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json
@@ -67,7 +67,17 @@
               "valueType": "xs:long"
             }
           ],
-          "second": "Unexpected string value",
+          "second": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json
@@ -76,7 +76,17 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Resource/contentType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Resource/contentType.json
@@ -4,7 +4,17 @@
       "assetInformation": {
         "assetKind": "NotApplicable",
         "defaultThumbnail": {
-          "contentType": [],
+          "contentType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "path": "file:/M5/%bA:'%9c%6b%ed%00Y*/%4C=4h:d:"
         },
         "globalAssetId": "something_eea66fa1"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Resource/path.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Resource/path.json
@@ -5,7 +5,17 @@
         "assetKind": "NotApplicable",
         "defaultThumbnail": {
           "contentType": "application/x-abiword",
-          "path": []
+          "path": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         },
         "globalAssetId": "something_eea66fa1"
       },

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json
@@ -5,7 +5,17 @@
         "assetKind": "NotApplicable",
         "specificAssetIds": [
           {
-            "externalSubjectId": "Unexpected string value",
+            "externalSubjectId": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "name": "something_b0b6ce88",
             "semanticId": {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/name.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/name.json
@@ -14,7 +14,17 @@
               ],
               "type": "ExternalReference"
             },
-            "name": [],
+            "name": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "semanticId": {
               "keys": [
                 {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json
@@ -15,7 +15,17 @@
               "type": "ExternalReference"
             },
             "name": "something_b0b6ce88",
-            "semanticId": "Unexpected string value",
+            "semanticId": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "supplementalSemanticIds": [
               {
                 "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/value.json
@@ -35,7 +35,17 @@
                 "type": "ModelReference"
               }
             ],
-            "value": []
+            "value": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ]
           }
         ]
       },

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json
@@ -1,7 +1,17 @@
 {
   "submodels": [
     {
-      "administration": "Unexpected string value",
+      "administration": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "category": "something_91042c92",
       "description": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/category.json
@@ -2,7 +2,17 @@
   "submodels": [
     {
       "administration": {},
-      "category": [],
+      "category": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "description": [
         {
           "language": "Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/id.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/id.json
@@ -47,7 +47,17 @@
           "name": "something_5b2d373a"
         }
       ],
-      "id": [],
+      "id": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "idShort": "fiZ",
       "kind": "Instance",
       "modelType": "Submodel",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/idShort.json
@@ -48,7 +48,17 @@
         }
       ],
       "id": "something_48c66017",
-      "idShort": [],
+      "idShort": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "kind": "Instance",
       "modelType": "Submodel",
       "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/kind.json
@@ -49,7 +49,17 @@
       ],
       "id": "something_48c66017",
       "idShort": "fiZ",
-      "kind": [],
+      "kind": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "modelType": "Submodel",
       "qualifiers": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json
@@ -57,7 +57,17 @@
           "valueType": "xs:int"
         }
       ],
-      "semanticId": "Unexpected string value",
+      "semanticId": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "submodelElements": [
         {
           "first": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/idShort.json
@@ -50,7 +50,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "SubmodelElementCollection",
           "qualifiers": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json
@@ -58,7 +58,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/category.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/category.json
@@ -5,7 +5,17 @@
       "modelType": "Submodel",
       "submodelElements": [
         {
-          "category": [],
+          "category": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "description": [
             {
               "language": "en",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/idShort.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/idShort.json
@@ -50,7 +50,17 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "idShort": [],
+          "idShort": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "modelType": "SubmodelElementList",
           "orderRelevant": true,
           "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/orderRelevant.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/orderRelevant.json
@@ -52,7 +52,17 @@
           ],
           "idShort": "PiXO1wyHierj",
           "modelType": "SubmodelElementList",
-          "orderRelevant": [],
+          "orderRelevant": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "qualifiers": [
             {
               "type": "something_500f973e",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json
@@ -59,7 +59,17 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": "Unexpected string value",
+          "semanticId": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "semanticIdListElement": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json
@@ -68,7 +68,17 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticIdListElement": "Unexpected string value",
+          "semanticIdListElement": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/typeValueListElement.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/typeValueListElement.json
@@ -88,7 +88,17 @@
               "type": "ModelReference"
             }
           ],
-          "typeValueListElement": [],
+          "typeValueListElement": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "value": [
             {
               "entityType": "SelfManagedEntity",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/valueTypeListElement.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/valueTypeListElement.json
@@ -95,7 +95,17 @@
               "modelType": "Entity"
             }
           ],
-          "valueTypeListElement": []
+          "valueTypeListElement": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/value.json
@@ -31,7 +31,17 @@
             "valueList": {
               "valueReferencePairs": [
                 {
-                  "value": [],
+                  "value": [
+                    {
+                      "keys": [
+                        {
+                          "type": "GlobalReference",
+                          "value": "unexpected instance"
+                        }
+                      ],
+                      "type": "ExternalReference"
+                    }
+                  ],
                   "valueId": {
                     "keys": [
                       {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json
@@ -32,7 +32,17 @@
               "valueReferencePairs": [
                 {
                   "value": "something_63781b6f",
-                  "valueId": "Unexpected string value"
+                  "valueId": [
+                    {
+                      "keys": [
+                        {
+                          "type": "GlobalReference",
+                          "value": "unexpected instance"
+                        }
+                      ],
+                      "type": "ExternalReference"
+                    }
+                  ]
                 }
               ]
             }

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json
@@ -1,5 +1,15 @@
 {
-  "observableReference": "Unexpected string value",
+  "observableReference": [
+    {
+      "keys": [
+        {
+          "type": "GlobalReference",
+          "value": "unexpected instance"
+        }
+      ],
+      "type": "ExternalReference"
+    }
+  ],
   "observableSemanticId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json
@@ -8,7 +8,17 @@
     ],
     "type": "ModelReference"
   },
-  "observableSemanticId": "Unexpected string value",
+  "observableSemanticId": [
+    {
+      "keys": [
+        {
+          "type": "GlobalReference",
+          "value": "unexpected instance"
+        }
+      ],
+      "type": "ExternalReference"
+    }
+  ],
   "payload": "/TsF2AbyQb1dIa0=",
   "source": {
     "keys": [

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/payload.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/payload.json
@@ -17,7 +17,17 @@
     ],
     "type": "ModelReference"
   },
-  "payload": [],
+  "payload": [
+    {
+      "keys": [
+        {
+          "type": "GlobalReference",
+          "value": "unexpected instance"
+        }
+      ],
+      "type": "ExternalReference"
+    }
+  ],
   "source": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json
@@ -18,7 +18,17 @@
     "type": "ModelReference"
   },
   "payload": "/TsF2AbyQb1dIa0=",
-  "source": "Unexpected string value",
+  "source": [
+    {
+      "keys": [
+        {
+          "type": "GlobalReference",
+          "value": "unexpected instance"
+        }
+      ],
+      "type": "ExternalReference"
+    }
+  ],
   "sourceSemanticId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json
@@ -31,7 +31,17 @@
     ],
     "type": "ModelReference"
   },
-  "sourceSemanticId": "Unexpected string value",
+  "sourceSemanticId": [
+    {
+      "keys": [
+        {
+          "type": "GlobalReference",
+          "value": "unexpected instance"
+        }
+      ],
+      "type": "ExternalReference"
+    }
+  ],
   "subjectId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json
@@ -40,7 +40,17 @@
     ],
     "type": "ModelReference"
   },
-  "subjectId": "Unexpected string value",
+  "subjectId": [
+    {
+      "keys": [
+        {
+          "type": "GlobalReference",
+          "value": "unexpected instance"
+        }
+      ],
+      "type": "ExternalReference"
+    }
+  ],
   "timeStamp": "2022-04-01T24:00:00-00:00",
   "topic": "something_8f13d2dd"
 }

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/timeStamp.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/timeStamp.json
@@ -49,6 +49,16 @@
     ],
     "type": "ExternalReference"
   },
-  "timeStamp": [],
+  "timeStamp": [
+    {
+      "keys": [
+        {
+          "type": "GlobalReference",
+          "value": "unexpected instance"
+        }
+      ],
+      "type": "ExternalReference"
+    }
+  ],
   "topic": "something_8f13d2dd"
 }

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/topic.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/topic.json
@@ -50,5 +50,15 @@
     "type": "ExternalReference"
   },
   "timeStamp": "2022-04-01T24:00:00-00:00",
-  "topic": []
+  "topic": [
+    {
+      "keys": [
+        {
+          "type": "GlobalReference",
+          "value": "unexpected instance"
+        }
+      ],
+      "type": "ExternalReference"
+    }
+  ]
 }

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/creator.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/creator.xml
@@ -32,7 +32,17 @@
 				</embeddedDataSpecifications>
 				<version>1230</version>
 				<revision>0</revision>
-				<creator>Unexpected string value</creator>
+				<creator>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</creator>
 				<templateId>something_cb08d136</templateId>
 			</administration>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/revision.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/revision.xml
@@ -31,7 +31,17 @@
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>
-				<revision/>
+				<revision>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</revision>
 				<creator>
 					<type>ModelReference</type>
 					<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/templateId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/templateId.xml
@@ -41,7 +41,17 @@
 						</key>
 					</keys>
 				</creator>
-				<templateId/>
+				<templateId>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</templateId>
 			</administration>
 			<id>something_142922d6</id>
 			<assetInformation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/version.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/version.xml
@@ -30,7 +30,17 @@
 						</dataSpecificationContent>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
-				<version/>
+				<version>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</version>
 				<revision>0</revision>
 				<creator>
 					<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/first.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/first.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<first>Unexpected string value</first>
+					<first>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</first>
 					<second>
 						<type>ExternalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>something_d7cf2dff</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/second.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/second.xml
@@ -86,7 +86,17 @@
 							</key>
 						</keys>
 					</first>
-					<second>Unexpected string value</second>
+					<second>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</second>
 					<annotations>
 						<multiLanguageProperty/>
 					</annotations>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/administration.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/administration.xml
@@ -20,7 +20,17 @@
 					<text>something_0c9e872c</text>
 				</langStringTextType>
 			</description>
-			<administration>Unexpected string value</administration>
+			<administration>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</administration>
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/assetInformation.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/assetInformation.xml
@@ -59,7 +59,17 @@
 					</key>
 				</keys>
 			</derivedFrom>
-			<assetInformation>Unexpected string value</assetInformation>
+			<assetInformation>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</assetInformation>
 			<submodels>
 				<reference>
 					<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/category.xml
@@ -6,7 +6,17 @@
 					<name>something_94548e46</name>
 				</extension>
 			</extensions>
-			<category/>
+			<category>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</category>
 			<idShort>PiXO1wyHierj</idShort>
 			<displayName>
 				<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/derivedFrom.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/derivedFrom.xml
@@ -50,7 +50,17 @@
 					</dataSpecificationContent>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
-			<derivedFrom>Unexpected string value</derivedFrom>
+			<derivedFrom>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</derivedFrom>
 			<assetInformation>
 				<assetKind>NotApplicable</assetKind>
 				<globalAssetId>something_eea66fa1</globalAssetId>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/id.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/id.xml
@@ -21,7 +21,17 @@
 				</langStringTextType>
 			</description>
 			<administration/>
-			<id/>
+			<id>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
 					<dataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/idShort.xml
@@ -7,7 +7,17 @@
 				</extension>
 			</extensions>
 			<category>something_1dc62cea</category>
-			<idShort/>
+			<idShort>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</idShort>
 			<displayName>
 				<langStringNameType>
 					<language>de-CH</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/assetKind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/assetKind.xml
@@ -3,7 +3,17 @@
 		<assetAdministrationShell>
 			<id>something_142922d6</id>
 			<assetInformation>
-				<assetKind/>
+				<assetKind>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</assetKind>
 				<globalAssetId>something_c71f0c8f</globalAssetId>
 				<assetType>something_9f4c5692</assetType>
 				<defaultThumbnail>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/assetType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/assetType.xml
@@ -5,7 +5,17 @@
 			<assetInformation>
 				<assetKind>NotApplicable</assetKind>
 				<globalAssetId>something_c71f0c8f</globalAssetId>
-				<assetType/>
+				<assetType>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</assetType>
 				<defaultThumbnail>
 					<path>file:/M5/%bA:'%9c%6b%ed%00Y*/%4C=4h:d:</path>
 				</defaultThumbnail>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/defaultThumbnail.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/defaultThumbnail.xml
@@ -6,7 +6,17 @@
 				<assetKind>NotApplicable</assetKind>
 				<globalAssetId>something_c71f0c8f</globalAssetId>
 				<assetType>something_9f4c5692</assetType>
-				<defaultThumbnail>Unexpected string value</defaultThumbnail>
+				<defaultThumbnail>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</defaultThumbnail>
 			</assetInformation>
 		</assetAdministrationShell>
 	</assetAdministrationShells>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/globalAssetId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/globalAssetId.xml
@@ -4,7 +4,17 @@
 			<id>something_142922d6</id>
 			<assetInformation>
 				<assetKind>NotApplicable</assetKind>
-				<globalAssetId/>
+				<globalAssetId>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</globalAssetId>
 				<assetType>something_9f4c5692</assetType>
 				<defaultThumbnail>
 					<path>file:/M5/%bA:'%9c%6b%ed%00Y*/%4C=4h:d:</path>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/direction.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/direction.xml
@@ -86,7 +86,17 @@
 							</key>
 						</keys>
 					</observed>
-					<direction/>
+					<direction>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</direction>
 					<state>off</state>
 					<messageTopic>something_99f1a7ac</messageTopic>
 					<messageBroker>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>something_d7cf2dff</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/lastUpdate.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/lastUpdate.xml
@@ -98,7 +98,17 @@
 							</key>
 						</keys>
 					</messageBroker>
-					<lastUpdate/>
+					<lastUpdate>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</lastUpdate>
 					<minInterval>-P1Y</minInterval>
 					<maxInterval>PT130S</maxInterval>
 				</basicEventElement>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/maxInterval.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/maxInterval.xml
@@ -100,7 +100,17 @@
 					</messageBroker>
 					<lastUpdate>-3020-08-21T24:00:00.0Z</lastUpdate>
 					<minInterval>-P1Y</minInterval>
-					<maxInterval/>
+					<maxInterval>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</maxInterval>
 				</basicEventElement>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml
@@ -89,7 +89,17 @@
 					<direction>output</direction>
 					<state>off</state>
 					<messageTopic>something_99f1a7ac</messageTopic>
-					<messageBroker>Unexpected string value</messageBroker>
+					<messageBroker>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</messageBroker>
 					<lastUpdate>-3020-08-21T24:00:00.0Z</lastUpdate>
 					<minInterval>-P1Y</minInterval>
 					<maxInterval>PT130S</maxInterval>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageTopic.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageTopic.xml
@@ -88,7 +88,17 @@
 					</observed>
 					<direction>output</direction>
 					<state>off</state>
-					<messageTopic/>
+					<messageTopic>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</messageTopic>
 					<messageBroker>
 						<type>ModelReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/minInterval.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/minInterval.xml
@@ -99,7 +99,17 @@
 						</keys>
 					</messageBroker>
 					<lastUpdate>-3020-08-21T24:00:00.0Z</lastUpdate>
-					<minInterval/>
+					<minInterval>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</minInterval>
 					<maxInterval>PT130S</maxInterval>
 				</basicEventElement>
 			</submodelElements>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<observed>Unexpected string value</observed>
+					<observed>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</observed>
 					<direction>output</direction>
 					<state>off</state>
 					<messageTopic>something_99f1a7ac</messageTopic>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/state.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/state.xml
@@ -87,7 +87,17 @@
 						</keys>
 					</observed>
 					<direction>output</direction>
-					<state/>
+					<state>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</state>
 					<messageTopic>something_99f1a7ac</messageTopic>
 					<messageBroker>
 						<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/contentType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/contentType.xml
@@ -78,7 +78,17 @@
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>
-					<contentType/>
+					<contentType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</contentType>
 				</blob>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>VARIABLE</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/value.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<value/>
+					<value>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</value>
 					<contentType>'VbrwFrYTU/fO7NnLxq   	; 	MX.`10dB732`X5yRy=I56Ov9Us	 ;		 pRb~~hdw_C%2Zf=&quot;&quot;			    			 	 		 	  ; h=1t</contentType>
 				</blob>
 			</submodelElements>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>something_d7cf2dff</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml
@@ -20,7 +20,17 @@
 					<text>something_863a162e</text>
 				</langStringTextType>
 			</description>
-			<administration>Unexpected string value</administration>
+			<administration>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</administration>
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/category.xml
@@ -6,7 +6,17 @@
 					<name>something_4b532e77</name>
 				</extension>
 			</extensions>
-			<category/>
+			<category>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</category>
 			<idShort>fiZ</idShort>
 			<displayName>
 				<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/id.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/id.xml
@@ -21,7 +21,17 @@
 				</langStringTextType>
 			</description>
 			<administration/>
-			<id/>
+			<id>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
 					<dataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/idShort.xml
@@ -7,7 +7,17 @@
 				</extension>
 			</extensions>
 			<category>something_07a45fb3</category>
-			<idShort/>
+			<idShort>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</idShort>
 			<displayName>
 				<langStringNameType>
 					<language>x-Sw4u3ZDO-nJLabnE</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/dataType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/dataType.xml
@@ -43,7 +43,17 @@
 							</unitId>
 							<sourceOfDefinition>something_1bd907c8</sourceOfDefinition>
 							<symbol>something_c13116d7</symbol>
-							<dataType/>
+							<dataType>
+								<reference>
+									<type>ExternalReference</type>
+									<keys>
+										<key>
+											<type>GlobalReference</type>
+											<value>unexpected instance</value>
+										</key>
+									</keys>
+								</reference>
+							</dataType>
 							<definition>
 								<langStringDefinitionTypeIec61360>
 									<language>X-33DQI-g</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/levelType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/levelType.xml
@@ -52,7 +52,17 @@
 							</definition>
 							<valueFormat>something_f019e5a8</valueFormat>
 							<value>something_13759f45</value>
-							<levelType>Unexpected string value</levelType>
+							<levelType>
+								<reference>
+									<type>ExternalReference</type>
+									<keys>
+										<key>
+											<type>GlobalReference</type>
+											<value>unexpected instance</value>
+										</key>
+									</keys>
+								</reference>
+							</levelType>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
 				</embeddedDataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/sourceOfDefinition.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/sourceOfDefinition.xml
@@ -41,7 +41,17 @@
 									</key>
 								</keys>
 							</unitId>
-							<sourceOfDefinition/>
+							<sourceOfDefinition>
+								<reference>
+									<type>ExternalReference</type>
+									<keys>
+										<key>
+											<type>GlobalReference</type>
+											<value>unexpected instance</value>
+										</key>
+									</keys>
+								</reference>
+							</sourceOfDefinition>
 							<symbol>something_c13116d7</symbol>
 							<dataType>DATE</dataType>
 							<definition>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/symbol.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/symbol.xml
@@ -42,7 +42,17 @@
 								</keys>
 							</unitId>
 							<sourceOfDefinition>something_1bd907c8</sourceOfDefinition>
-							<symbol/>
+							<symbol>
+								<reference>
+									<type>ExternalReference</type>
+									<keys>
+										<key>
+											<type>GlobalReference</type>
+											<value>unexpected instance</value>
+										</key>
+									</keys>
+								</reference>
+							</symbol>
 							<dataType>DATE</dataType>
 							<definition>
 								<langStringDefinitionTypeIec61360>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unit.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unit.xml
@@ -31,7 +31,17 @@
 									<text>something_65af8271</text>
 								</langStringShortNameTypeIec61360>
 							</shortName>
-							<unit/>
+							<unit>
+								<reference>
+									<type>ExternalReference</type>
+									<keys>
+										<key>
+											<type>GlobalReference</type>
+											<value>unexpected instance</value>
+										</key>
+									</keys>
+								</reference>
+							</unit>
 							<unitId>
 								<type>ModelReference</type>
 								<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unitId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unitId.xml
@@ -32,7 +32,17 @@
 								</langStringShortNameTypeIec61360>
 							</shortName>
 							<unit>something_a6bd9450</unit>
-							<unitId>Unexpected string value</unitId>
+							<unitId>
+								<reference>
+									<type>ExternalReference</type>
+									<keys>
+										<key>
+											<type>GlobalReference</type>
+											<value>unexpected instance</value>
+										</key>
+									</keys>
+								</reference>
+							</unitId>
 							<sourceOfDefinition>something_1bd907c8</sourceOfDefinition>
 							<symbol>something_c13116d7</symbol>
 							<dataType>DATE</dataType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/value.xml
@@ -51,7 +51,17 @@
 								</langStringDefinitionTypeIec61360>
 							</definition>
 							<valueFormat>something_f019e5a8</valueFormat>
-							<value/>
+							<value>
+								<reference>
+									<type>ExternalReference</type>
+									<keys>
+										<key>
+											<type>GlobalReference</type>
+											<value>unexpected instance</value>
+										</key>
+									</keys>
+								</reference>
+							</value>
 							<levelType>
 								<min>true</min>
 								<nom>true</nom>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/valueFormat.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/valueFormat.xml
@@ -50,7 +50,17 @@
 									<text>something_2ae95f9f</text>
 								</langStringDefinitionTypeIec61360>
 							</definition>
-							<valueFormat/>
+							<valueFormat>
+								<reference>
+									<type>ExternalReference</type>
+									<keys>
+										<key>
+											<type>GlobalReference</type>
+											<value>unexpected instance</value>
+										</key>
+									</keys>
+								</reference>
+							</valueFormat>
 							<value>something_13759f45</value>
 							<levelType>
 								<min>true</min>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecification.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecification.xml
@@ -4,7 +4,17 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
-					<dataSpecification>Unexpected string value</dataSpecification>
+					<dataSpecification>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecificationContent.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecificationContent.xml
@@ -13,7 +13,17 @@
 							</key>
 						</keys>
 					</dataSpecification>
-					<dataSpecificationContent>Unexpected string value</dataSpecificationContent>
+					<dataSpecificationContent>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</dataSpecificationContent>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/entityType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/entityType.xml
@@ -82,7 +82,17 @@
 							<valueType>xs:gMonthDay</valueType>
 						</range>
 					</statements>
-					<entityType/>
+					<entityType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</entityType>
 				</entity>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>something_d7cf2dff</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/name.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/name.xml
@@ -23,7 +23,17 @@
 							</keys>
 						</reference>
 					</supplementalSemanticIds>
-					<name/>
+					<name>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</name>
 					<valueType>xs:unsignedShort</valueType>
 					<value>10233</value>
 					<refersTo>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/semanticId.xml
@@ -3,7 +3,17 @@
 		<assetAdministrationShell>
 			<extensions>
 				<extension>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ExternalReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/value.xml
@@ -25,7 +25,17 @@
 					</supplementalSemanticIds>
 					<name>something_aae6caf4</name>
 					<valueType>xs:unsignedShort</valueType>
-					<value/>
+					<value>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</value>
 					<refersTo>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/valueType.xml
@@ -24,7 +24,17 @@
 						</reference>
 					</supplementalSemanticIds>
 					<name>something_aae6caf4</name>
-					<valueType/>
+					<valueType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueType>
 					<value>10233</value>
 					<refersTo>
 						<reference>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/contentType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/contentType.xml
@@ -78,7 +78,17 @@
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>file:/path/to/somewhere</value>
-					<contentType/>
+					<contentType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</contentType>
 				</file>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>VARIABLE</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/value.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<value/>
+					<value>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</value>
 					<contentType>'VbrwFrYTU/fO7NnLxq   	; 	MX.`10dB732`X5yRy=I56Ov9Us	 ;		 pRb~~hdw_C%2Zf=&quot;&quot;			    			 	 		 	  ; h=1t</contentType>
 				</file>
 			</submodelElements>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/type.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/type.xml
@@ -6,7 +6,17 @@
 				<type>ModelReference</type>
 				<keys>
 					<key>
-						<type/>
+						<type>
+							<reference>
+								<type>ExternalReference</type>
+								<keys>
+									<key>
+										<type>GlobalReference</type>
+										<value>unexpected instance</value>
+									</key>
+								</keys>
+							</reference>
+						</type>
 						<value>urn:an-example08:f3f73640</value>
 					</key>
 				</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/value.xml
@@ -7,7 +7,17 @@
 				<keys>
 					<key>
 						<type>AssetAdministrationShell</type>
-						<value/>
+						<value>
+							<reference>
+								<type>ExternalReference</type>
+								<keys>
+									<key>
+										<type>GlobalReference</type>
+										<value>unexpected instance</value>
+									</key>
+								</keys>
+							</reference>
+						</value>
 					</key>
 				</keys>
 			</derivedFrom>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringDefinitionTypeIec61360/language.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringDefinitionTypeIec61360/language.xml
@@ -27,7 +27,17 @@
 							</preferredName>
 							<definition>
 								<langStringDefinitionTypeIec61360>
-									<language/>
+									<language>
+										<reference>
+											<type>ExternalReference</type>
+											<keys>
+												<key>
+													<type>GlobalReference</type>
+													<value>unexpected instance</value>
+												</key>
+											</keys>
+										</reference>
+									</language>
 									<text>something_29357dd5</text>
 								</langStringDefinitionTypeIec61360>
 							</definition>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringDefinitionTypeIec61360/text.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringDefinitionTypeIec61360/text.xml
@@ -28,7 +28,17 @@
 							<definition>
 								<langStringDefinitionTypeIec61360>
 									<language>X-33DQI-g</language>
-									<text/>
+									<text>
+										<reference>
+											<type>ExternalReference</type>
+											<keys>
+												<key>
+													<type>GlobalReference</type>
+													<value>unexpected instance</value>
+												</key>
+											</keys>
+										</reference>
+									</text>
 								</langStringDefinitionTypeIec61360>
 							</definition>
 							<value>something_13759f45</value>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringNameType/language.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringNameType/language.xml
@@ -3,7 +3,17 @@
 		<assetAdministrationShell>
 			<displayName>
 				<langStringNameType>
-					<language/>
+					<language>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</language>
 					<text>something_09c304fd</text>
 				</langStringNameType>
 			</displayName>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringNameType/text.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringNameType/text.xml
@@ -4,7 +4,17 @@
 			<displayName>
 				<langStringNameType>
 					<language>en</language>
-					<text/>
+					<text>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</text>
 				</langStringNameType>
 			</displayName>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringPreferredNameTypeIec61360/language.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringPreferredNameTypeIec61360/language.xml
@@ -17,7 +17,17 @@
 						<dataSpecificationIec61360>
 							<preferredName>
 								<langStringPreferredNameTypeIec61360>
-									<language/>
+									<language>
+										<reference>
+											<type>ExternalReference</type>
+											<keys>
+												<key>
+													<type>GlobalReference</type>
+													<value>unexpected instance</value>
+												</key>
+											</keys>
+										</reference>
+									</language>
 									<text>something_c98d9907</text>
 								</langStringPreferredNameTypeIec61360>
 								<langStringPreferredNameTypeIec61360>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringPreferredNameTypeIec61360/text.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringPreferredNameTypeIec61360/text.xml
@@ -18,7 +18,17 @@
 							<preferredName>
 								<langStringPreferredNameTypeIec61360>
 									<language>X-33DQI-g</language>
-									<text/>
+									<text>
+										<reference>
+											<type>ExternalReference</type>
+											<keys>
+												<key>
+													<type>GlobalReference</type>
+													<value>unexpected instance</value>
+												</key>
+											</keys>
+										</reference>
+									</text>
 								</langStringPreferredNameTypeIec61360>
 								<langStringPreferredNameTypeIec61360>
 									<language>en-UK</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringShortNameTypeIec61360/language.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringShortNameTypeIec61360/language.xml
@@ -27,7 +27,17 @@
 							</preferredName>
 							<shortName>
 								<langStringShortNameTypeIec61360>
-									<language/>
+									<language>
+										<reference>
+											<type>ExternalReference</type>
+											<keys>
+												<key>
+													<type>GlobalReference</type>
+													<value>unexpected instance</value>
+												</key>
+											</keys>
+										</reference>
+									</language>
 									<text>something_75139f2c</text>
 								</langStringShortNameTypeIec61360>
 							</shortName>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringShortNameTypeIec61360/text.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringShortNameTypeIec61360/text.xml
@@ -28,7 +28,17 @@
 							<shortName>
 								<langStringShortNameTypeIec61360>
 									<language>X-33DQI-g</language>
-									<text/>
+									<text>
+										<reference>
+											<type>ExternalReference</type>
+											<keys>
+												<key>
+													<type>GlobalReference</type>
+													<value>unexpected instance</value>
+												</key>
+											</keys>
+										</reference>
+									</text>
 								</langStringShortNameTypeIec61360>
 							</shortName>
 							<value>something_13759f45</value>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringTextType/language.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringTextType/language.xml
@@ -3,7 +3,17 @@
 		<assetAdministrationShell>
 			<description>
 				<langStringTextType>
-					<language/>
+					<language>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</language>
 					<text>something_5340dd75</text>
 				</langStringTextType>
 			</description>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringTextType/text.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/langStringTextType/text.xml
@@ -4,7 +4,17 @@
 			<description>
 				<langStringTextType>
 					<language>de-CH</language>
-					<text/>
+					<text>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</text>
 				</langStringTextType>
 			</description>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/levelType/max.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/levelType/max.xml
@@ -30,7 +30,17 @@
 								<min>true</min>
 								<nom>true</nom>
 								<typ>true</typ>
-								<max/>
+								<max>
+									<reference>
+										<type>ExternalReference</type>
+										<keys>
+											<key>
+												<type>GlobalReference</type>
+												<value>unexpected instance</value>
+											</key>
+										</keys>
+									</reference>
+								</max>
 							</levelType>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/levelType/min.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/levelType/min.xml
@@ -27,7 +27,17 @@
 							</preferredName>
 							<value>something_13759f45</value>
 							<levelType>
-								<min/>
+								<min>
+									<reference>
+										<type>ExternalReference</type>
+										<keys>
+											<key>
+												<type>GlobalReference</type>
+												<value>unexpected instance</value>
+											</key>
+										</keys>
+									</reference>
+								</min>
 								<nom>true</nom>
 								<typ>true</typ>
 								<max>true</max>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/levelType/nom.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/levelType/nom.xml
@@ -28,7 +28,17 @@
 							<value>something_13759f45</value>
 							<levelType>
 								<min>true</min>
-								<nom/>
+								<nom>
+									<reference>
+										<type>ExternalReference</type>
+										<keys>
+											<key>
+												<type>GlobalReference</type>
+												<value>unexpected instance</value>
+											</key>
+										</keys>
+									</reference>
+								</nom>
 								<typ>true</typ>
 								<max>true</max>
 							</levelType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/levelType/typ.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/levelType/typ.xml
@@ -29,7 +29,17 @@
 							<levelType>
 								<min>true</min>
 								<nom>true</nom>
-								<typ/>
+								<typ>
+									<reference>
+										<type>ExternalReference</type>
+										<keys>
+											<key>
+												<type>GlobalReference</type>
+												<value>unexpected instance</value>
+											</key>
+										</keys>
+									</reference>
+								</typ>
 								<max>true</max>
 							</levelType>
 						</dataSpecificationIec61360>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>VARIABLE</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml
@@ -83,7 +83,17 @@
 							<text>something_cd7e6587</text>
 						</langStringTextType>
 					</value>
-					<valueId>Unexpected string value</valueId>
+					<valueId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueId>
 				</multiLanguageProperty>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>something_d7cf2dff</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operationVariable/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operationVariable/value.xml
@@ -7,7 +7,17 @@
 					<idShort>something3fdd3eb4</idShort>
 					<inputVariables>
 						<operationVariable>
-							<value>Unexpected string value</value>
+							<value>
+								<reference>
+									<type>ExternalReference</type>
+									<keys>
+										<key>
+											<type>GlobalReference</type>
+											<value>unexpected instance</value>
+										</key>
+									</keys>
+								</reference>
+							</value>
 						</operationVariable>
 					</inputVariables>
 				</operation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>VARIABLE</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/value.xml
@@ -78,7 +78,17 @@
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>
-					<value/>
+					<value>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</value>
 					<valueId>
 						<type>ModelReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml
@@ -79,7 +79,17 @@
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>
 					<value>0061707</value>
-					<valueId>Unexpected string value</valueId>
+					<valueId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueId>
 				</property>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<valueType/>
+					<valueType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueType>
 					<value>0061707</value>
 					<valueId>
 						<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/kind.xml
@@ -25,7 +25,17 @@
 							</keys>
 						</reference>
 					</supplementalSemanticIds>
-					<kind/>
+					<kind>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</kind>
 					<type>something_5964ab43</type>
 					<valueType>xs:integer</valueType>
 					<value>001</value>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/semanticId.xml
@@ -5,7 +5,17 @@
 			<kind>Template</kind>
 			<qualifiers>
 				<qualifier>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ExternalReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/type.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/type.xml
@@ -26,7 +26,17 @@
 						</reference>
 					</supplementalSemanticIds>
 					<kind>TemplateQualifier</kind>
-					<type/>
+					<type>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</type>
 					<valueType>xs:integer</valueType>
 					<value>001</value>
 					<valueId>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/value.xml
@@ -28,7 +28,17 @@
 					<kind>TemplateQualifier</kind>
 					<type>something_5964ab43</type>
 					<valueType>xs:integer</valueType>
-					<value/>
+					<value>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</value>
 					<valueId>
 						<type>ModelReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueId.xml
@@ -29,7 +29,17 @@
 					<type>something_5964ab43</type>
 					<valueType>xs:integer</valueType>
 					<value>001</value>
-					<valueId>Unexpected string value</valueId>
+					<valueId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueId>
 				</qualifier>
 			</qualifiers>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueType.xml
@@ -27,7 +27,17 @@
 					</supplementalSemanticIds>
 					<kind>TemplateQualifier</kind>
 					<type>something_5964ab43</type>
-					<valueType/>
+					<valueType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueType>
 					<value>001</value>
 					<valueId>
 						<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>VARIABLE</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/max.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/max.xml
@@ -78,7 +78,17 @@
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>
-					<max/>
+					<max>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</max>
 				</range>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<valueType/>
+					<valueType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueType>
 					<max>1234.1234567890123456789012345678901234567890123456789012345678901234567890</max>
 				</range>
 			</submodelElements>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml
@@ -4,7 +4,17 @@
 			<id>something_142922d6</id>
 			<derivedFrom>
 				<type>ModelReference</type>
-				<referredSemanticId>Unexpected string value</referredSemanticId>
+				<referredSemanticId>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</referredSemanticId>
 				<keys>
 					<key>
 						<type>AssetAdministrationShell</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/type.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/type.xml
@@ -3,7 +3,17 @@
 		<assetAdministrationShell>
 			<id>something_142922d6</id>
 			<derivedFrom>
-				<type/>
+				<type>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</type>
 				<referredSemanticId>
 					<type>ExternalReference</type>
 					<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>VARIABLE</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<value>Unexpected string value</value>
+					<value>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</value>
 				</referenceElement>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/first.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/first.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<first>Unexpected string value</first>
+					<first>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</first>
 					<second>
 						<type>ExternalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>something_d7cf2dff</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/second.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/second.xml
@@ -86,7 +86,17 @@
 							</key>
 						</keys>
 					</first>
-					<second>Unexpected string value</second>
+					<second>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</second>
 				</relationshipElement>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/resource/contentType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/resource/contentType.xml
@@ -7,7 +7,17 @@
 				<globalAssetId>something_eea66fa1</globalAssetId>
 				<defaultThumbnail>
 					<path>file:/M5/%bA:'%9c%6b%ed%00Y*/%4C=4h:d:</path>
-					<contentType/>
+					<contentType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</contentType>
 				</defaultThumbnail>
 			</assetInformation>
 		</assetAdministrationShell>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/resource/path.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/resource/path.xml
@@ -6,7 +6,17 @@
 				<assetKind>NotApplicable</assetKind>
 				<globalAssetId>something_eea66fa1</globalAssetId>
 				<defaultThumbnail>
-					<path/>
+					<path>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</path>
 					<contentType>application/x-abiword</contentType>
 				</defaultThumbnail>
 			</assetInformation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/externalSubjectId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/externalSubjectId.xml
@@ -28,7 +28,17 @@
 						</supplementalSemanticIds>
 						<name>something_b0b6ce88</name>
 						<value>something_a37abe43</value>
-						<externalSubjectId>Unexpected string value</externalSubjectId>
+						<externalSubjectId>
+							<reference>
+								<type>ExternalReference</type>
+								<keys>
+									<key>
+										<type>GlobalReference</type>
+										<value>unexpected instance</value>
+									</key>
+								</keys>
+							</reference>
+						</externalSubjectId>
 					</specificAssetId>
 				</specificAssetIds>
 			</assetInformation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/name.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/name.xml
@@ -26,7 +26,17 @@
 								</keys>
 							</reference>
 						</supplementalSemanticIds>
-						<name/>
+						<name>
+							<reference>
+								<type>ExternalReference</type>
+								<keys>
+									<key>
+										<type>GlobalReference</type>
+										<value>unexpected instance</value>
+									</key>
+								</keys>
+							</reference>
+						</name>
 						<value>something_a37abe43</value>
 						<externalSubjectId>
 							<type>ExternalReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/semanticId.xml
@@ -6,7 +6,17 @@
 				<assetKind>NotApplicable</assetKind>
 				<specificAssetIds>
 					<specificAssetId>
-						<semanticId>Unexpected string value</semanticId>
+						<semanticId>
+							<reference>
+								<type>ExternalReference</type>
+								<keys>
+									<key>
+										<type>GlobalReference</type>
+										<value>unexpected instance</value>
+									</key>
+								</keys>
+							</reference>
+						</semanticId>
 						<supplementalSemanticIds>
 							<reference>
 								<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/value.xml
@@ -27,7 +27,17 @@
 							</reference>
 						</supplementalSemanticIds>
 						<name>something_b0b6ce88</name>
-						<value/>
+						<value>
+							<reference>
+								<type>ExternalReference</type>
+								<keys>
+									<key>
+										<type>GlobalReference</type>
+										<value>unexpected instance</value>
+									</key>
+								</keys>
+							</reference>
+						</value>
 						<externalSubjectId>
 							<type>ExternalReference</type>
 							<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/administration.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/administration.xml
@@ -20,7 +20,17 @@
 					<text>something_9a9e9635</text>
 				</langStringTextType>
 			</description>
-			<administration>Unexpected string value</administration>
+			<administration>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</administration>
 			<id>something_48c66017</id>
 			<kind>Instance</kind>
 			<semanticId>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/category.xml
@@ -6,7 +6,17 @@
 					<name>something_5b2d373a</name>
 				</extension>
 			</extensions>
-			<category/>
+			<category>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</category>
 			<idShort>fiZ</idShort>
 			<displayName>
 				<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/id.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/id.xml
@@ -21,7 +21,17 @@
 				</langStringTextType>
 			</description>
 			<administration/>
-			<id/>
+			<id>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</id>
 			<kind>Instance</kind>
 			<semanticId>
 				<type>ExternalReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/idShort.xml
@@ -7,7 +7,17 @@
 				</extension>
 			</extensions>
 			<category>something_91042c92</category>
-			<idShort/>
+			<idShort>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</idShort>
 			<displayName>
 				<langStringNameType>
 					<language>en</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/kind.xml
@@ -22,7 +22,17 @@
 			</description>
 			<administration/>
 			<id>something_48c66017</id>
-			<kind/>
+			<kind>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</kind>
 			<semanticId>
 				<type>ExternalReference</type>
 				<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/semanticId.xml
@@ -23,7 +23,17 @@
 			<administration/>
 			<id>something_48c66017</id>
 			<kind>Instance</kind>
-			<semanticId>Unexpected string value</semanticId>
+			<semanticId>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</semanticId>
 			<supplementalSemanticIds>
 				<reference>
 					<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>something_d7cf2dff</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/category.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/category.xml
@@ -9,7 +9,17 @@
 							<name>something_aa1af8b3</name>
 						</extension>
 					</extensions>
-					<category/>
+					<category>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</category>
 					<idShort>PiXO1wyHierj</idShort>
 					<displayName>
 						<langStringNameType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/idShort.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/idShort.xml
@@ -10,7 +10,17 @@
 						</extension>
 					</extensions>
 					<category>something_d7cf2dff</category>
-					<idShort/>
+					<idShort>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</idShort>
 					<displayName>
 						<langStringNameType>
 							<language>Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/orderRelevant.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/orderRelevant.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<orderRelevant/>
+					<orderRelevant>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</orderRelevant>
 					<semanticIdListElement>
 						<type>ModelReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticId.xml
@@ -23,7 +23,17 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>Unexpected string value</semanticId>
+					<semanticId>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticIdListElement.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticIdListElement.xml
@@ -78,7 +78,17 @@
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>
-					<semanticIdListElement>Unexpected string value</semanticIdListElement>
+					<semanticIdListElement>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</semanticIdListElement>
 					<typeValueListElement>Entity</typeValueListElement>
 					<valueTypeListElement>xs:byte</valueTypeListElement>
 					<value>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/typeValueListElement.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/typeValueListElement.xml
@@ -87,7 +87,17 @@
 							</key>
 						</keys>
 					</semanticIdListElement>
-					<typeValueListElement/>
+					<typeValueListElement>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</typeValueListElement>
 					<valueTypeListElement>xs:byte</valueTypeListElement>
 					<value>
 						<entity>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/valueTypeListElement.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/valueTypeListElement.xml
@@ -88,7 +88,17 @@
 						</keys>
 					</semanticIdListElement>
 					<typeValueListElement>Entity</typeValueListElement>
-					<valueTypeListElement/>
+					<valueTypeListElement>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueTypeListElement>
 					<value>
 						<entity>
 							<entityType>SelfManagedEntity</entityType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/value.xml
@@ -28,7 +28,17 @@
 							<valueList>
 								<valueReferencePairs>
 									<valueReferencePair>
-										<value/>
+										<value>
+											<reference>
+												<type>ExternalReference</type>
+												<keys>
+													<key>
+														<type>GlobalReference</type>
+														<value>unexpected instance</value>
+													</key>
+												</keys>
+											</reference>
+										</value>
 										<valueId>
 											<type>ExternalReference</type>
 											<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/valueId.xml
@@ -29,7 +29,17 @@
 								<valueReferencePairs>
 									<valueReferencePair>
 										<value>something_63781b6f</value>
-										<valueId>Unexpected string value</valueId>
+										<valueId>
+											<reference>
+												<type>ExternalReference</type>
+												<keys>
+													<key>
+														<type>GlobalReference</type>
+														<value>unexpected instance</value>
+													</key>
+												</keys>
+											</reference>
+										</valueId>
 									</valueReferencePair>
 								</valueReferencePairs>
 							</valueList>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableReference.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableReference.xml
@@ -21,7 +21,17 @@
 			</key>
 		</keys>
 	</sourceSemanticId>
-	<observableReference>Unexpected string value</observableReference>
+	<observableReference>
+		<reference>
+			<type>ExternalReference</type>
+			<keys>
+				<key>
+					<type>GlobalReference</type>
+					<value>unexpected instance</value>
+				</key>
+			</keys>
+		</reference>
+	</observableReference>
 	<observableSemanticId>
 		<type>ModelReference</type>
 		<keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableSemanticId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableSemanticId.xml
@@ -30,7 +30,17 @@
 			</key>
 		</keys>
 	</observableReference>
-	<observableSemanticId>Unexpected string value</observableSemanticId>
+	<observableSemanticId>
+		<reference>
+			<type>ExternalReference</type>
+			<keys>
+				<key>
+					<type>GlobalReference</type>
+					<value>unexpected instance</value>
+				</key>
+			</keys>
+		</reference>
+	</observableSemanticId>
 	<topic>something_8f13d2dd</topic>
 	<subjectId>
 		<type>ExternalReference</type>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/payload.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/payload.xml
@@ -50,5 +50,15 @@
 		</keys>
 	</subjectId>
 	<timeStamp>2022-04-01T24:00:00-00:00</timeStamp>
-	<payload/>
+	<payload>
+		<reference>
+			<type>ExternalReference</type>
+			<keys>
+				<key>
+					<type>GlobalReference</type>
+					<value>unexpected instance</value>
+				</key>
+			</keys>
+		</reference>
+	</payload>
 </eventPayload>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/source.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/source.xml
@@ -1,5 +1,15 @@
 <eventPayload xmlns="https://admin-shell.io/aas/3/0">
-	<source>Unexpected string value</source>
+	<source>
+		<reference>
+			<type>ExternalReference</type>
+			<keys>
+				<key>
+					<type>GlobalReference</type>
+					<value>unexpected instance</value>
+				</key>
+			</keys>
+		</reference>
+	</source>
 	<sourceSemanticId>
 		<type>ModelReference</type>
 		<keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/sourceSemanticId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/sourceSemanticId.xml
@@ -12,7 +12,17 @@
 			</key>
 		</keys>
 	</source>
-	<sourceSemanticId>Unexpected string value</sourceSemanticId>
+	<sourceSemanticId>
+		<reference>
+			<type>ExternalReference</type>
+			<keys>
+				<key>
+					<type>GlobalReference</type>
+					<value>unexpected instance</value>
+				</key>
+			</keys>
+		</reference>
+	</sourceSemanticId>
 	<observableReference>
 		<type>ModelReference</type>
 		<keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/subjectId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/subjectId.xml
@@ -40,7 +40,17 @@
 		</keys>
 	</observableSemanticId>
 	<topic>something_8f13d2dd</topic>
-	<subjectId>Unexpected string value</subjectId>
+	<subjectId>
+		<reference>
+			<type>ExternalReference</type>
+			<keys>
+				<key>
+					<type>GlobalReference</type>
+					<value>unexpected instance</value>
+				</key>
+			</keys>
+		</reference>
+	</subjectId>
 	<timeStamp>2022-04-01T24:00:00-00:00</timeStamp>
 	<payload>/TsF2AbyQb1dIa0=</payload>
 </eventPayload>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/timeStamp.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/timeStamp.xml
@@ -49,6 +49,16 @@
 			</key>
 		</keys>
 	</subjectId>
-	<timeStamp/>
+	<timeStamp>
+		<reference>
+			<type>ExternalReference</type>
+			<keys>
+				<key>
+					<type>GlobalReference</type>
+					<value>unexpected instance</value>
+				</key>
+			</keys>
+		</reference>
+	</timeStamp>
 	<payload>/TsF2AbyQb1dIa0=</payload>
 </eventPayload>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/topic.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/topic.xml
@@ -39,7 +39,17 @@
 			</key>
 		</keys>
 	</observableSemanticId>
-	<topic/>
+	<topic>
+		<reference>
+			<type>ExternalReference</type>
+			<keys>
+				<key>
+					<type>GlobalReference</type>
+					<value>unexpected instance</value>
+				</key>
+			</keys>
+		</reference>
+	</topic>
 	<subjectId>
 		<type>ExternalReference</type>
 		<keys>


### PR DESCRIPTION
Current type violations were not robust enough in XML as we could still de-serialize the object using an SDK even though it did not match the schema.

We generate a bit harsher type violations to make sure that the examples are indeed unserializable in SDKs.