### PR TITLE
Update to aas-core-meta, codegen 3191ea5, a384f52

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -2,4 +2,6 @@
 Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
+
+The revision of aas-core-codegen was: a384f52
 """

--- a/dev_scripts/update_to_aas_core_meta_and_codegen.py
+++ b/dev_scripts/update_to_aas_core_meta_and_codegen.py
@@ -143,7 +143,7 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: {aas_core_codegen_revision} 
+The revision of aas-core-codegen was: {aas_core_codegen_revision}
 """
 '''
     init_py.write_text(text, encoding="utf-8")

--- a/test_data/schema.xsd
+++ b/test_data/schema.xsd
@@ -35,6 +35,7 @@
           <xs:restriction base="xs:string">
             <xs:pattern value="(0|[1-9][0-9]*)"/>
             <xs:minLength value="1"/>
+            <xs:maxLength value="4"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -43,6 +44,7 @@
           <xs:restriction base="xs:string">
             <xs:pattern value="(0|[1-9][0-9]*)"/>
             <xs:minLength value="1"/>
+            <xs:maxLength value="4"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 3191ea5], and
* [aas-core-codegen a384f52].

[aas-core-meta 3191ea5]: https://github.com/aas-core-works/aas-core-meta/commit/3191ea5
[aas-core-codegen a384f52]: https://github.com/aas-core-works/aas-core-codegen/commit/a384f52