### PR TITLE
Make type violations more explicit for XML

### DIFF
--- a/aas_core3_0_testgen/generation.py
+++ b/aas_core3_0_testgen/generation.py
@@ -818,7 +818,9 @@ def _generate_type_violations(maximal_case: CaseMaximal) -> Iterator[CaseTypeVio
         # region Mutate
         type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-        if not isinstance(type_anno, intermediate.ListTypeAnnotation):
+        primitive_type = intermediate.try_primitive_type(type_anno)
+
+        if primitive_type is not None:
             unexpected_instance, _ = preserialization.preserialize(
                 aas_types.Reference(
                     type=aas_types.ReferenceTypes.EXTERNAL_REFERENCE,

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json
@@ -2,17 +2,7 @@
   "assetAdministrationShells": [
     {
       "administration": {
-        "creator": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ],
+        "creator": "Unexpected string value",
         "embeddedDataSpecifications": [
           {
             "dataSpecification": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json
@@ -56,17 +56,7 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "first": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "first": "Unexpected string value",
           "idShort": "PiXO1wyHierj",
           "modelType": "AnnotatedRelationshipElement",
           "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json
@@ -73,17 +73,7 @@
               "valueType": "xs:long"
             }
           ],
-          "second": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "second": "Unexpected string value",
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json
@@ -82,17 +82,7 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json
@@ -1,17 +1,7 @@
 {
   "assetAdministrationShells": [
     {
-      "administration": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "administration": "Unexpected string value",
       "assetInformation": {
         "assetKind": "NotApplicable",
         "globalAssetId": "something_eea66fa1"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json
@@ -2,17 +2,7 @@
   "assetAdministrationShells": [
     {
       "administration": {},
-      "assetInformation": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "assetInformation": "Unexpected string value",
       "category": "something_1dc62cea",
       "derivedFrom": {
         "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json
@@ -7,17 +7,7 @@
         "globalAssetId": "something_eea66fa1"
       },
       "category": "something_1dc62cea",
-      "derivedFrom": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "derivedFrom": "Unexpected string value",
       "description": [
         {
           "language": "Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/assetKind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/assetKind.json
@@ -2,17 +2,7 @@
   "assetAdministrationShells": [
     {
       "assetInformation": {
-        "assetKind": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ],
+        "assetKind": "Unexpected string value",
         "assetType": "something_9f4c5692",
         "defaultThumbnail": {
           "path": "file:/M5/%bA:'%9c%6b%ed%00Y*/%4C=4h:d:"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json
@@ -4,17 +4,7 @@
       "assetInformation": {
         "assetKind": "NotApplicable",
         "assetType": "something_9f4c5692",
-        "defaultThumbnail": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ],
+        "defaultThumbnail": "Unexpected string value",
         "globalAssetId": "something_c71f0c8f"
       },
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/direction.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/direction.json
@@ -12,17 +12,7 @@
               "text": "something_be9deae0"
             }
           ],
-          "direction": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "direction": "Unexpected string value",
           "displayName": [
             {
               "language": "Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json
@@ -54,17 +54,7 @@
           "idShort": "PiXO1wyHierj",
           "lastUpdate": "-3020-08-21T24:00:00.0Z",
           "maxInterval": "PT130S",
-          "messageBroker": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "messageBroker": "Unexpected string value",
           "messageTopic": "something_99f1a7ac",
           "minInterval": "-P1Y",
           "modelType": "BasicEventElement",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json
@@ -66,17 +66,7 @@
           "messageTopic": "something_99f1a7ac",
           "minInterval": "-P1Y",
           "modelType": "BasicEventElement",
-          "observed": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "observed": "Unexpected string value",
           "qualifiers": [
             {
               "type": "something_500f973e",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json
@@ -81,17 +81,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "state": "off",
           "supplementalSemanticIds": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/state.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/state.json
@@ -90,17 +90,7 @@
             ],
             "type": "ExternalReference"
           },
-          "state": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "state": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json
@@ -1,17 +1,7 @@
 {
   "conceptDescriptions": [
     {
-      "administration": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "administration": "Unexpected string value",
       "category": "something_07a45fb3",
       "description": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/dataType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/dataType.json
@@ -17,17 +17,7 @@
             "type": "ExternalReference"
           },
           "dataSpecificationContent": {
-            "dataType": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "dataType": "Unexpected string value",
             "definition": [
               {
                 "language": "X-33DQI-g",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json
@@ -24,17 +24,7 @@
                 "text": "something_2ae95f9f"
               }
             ],
-            "levelType": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "levelType": "Unexpected string value",
             "modelType": "DataSpecificationIec61360",
             "preferredName": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json
@@ -50,17 +50,7 @@
             "sourceOfDefinition": "something_1bd907c8",
             "symbol": "something_c13116d7",
             "unit": "something_a6bd9450",
-            "unitId": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "unitId": "Unexpected string value",
             "value": "something_13759f45",
             "valueFormat": "something_f019e5a8"
           }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json
@@ -7,17 +7,7 @@
       },
       "embeddedDataSpecifications": [
         {
-          "dataSpecification": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "dataSpecification": "Unexpected string value",
           "dataSpecificationContent": {
             "modelType": "DataSpecificationIec61360",
             "preferredName": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecificationContent.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecificationContent.json
@@ -16,17 +16,7 @@
             ],
             "type": "ExternalReference"
           },
-          "dataSpecificationContent": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "dataSpecificationContent": "Unexpected string value"
         }
       ],
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/entityType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/entityType.json
@@ -45,17 +45,7 @@
               }
             }
           ],
-          "entityType": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "entityType": "Unexpected string value",
           "extensions": [
             {
               "name": "something_aa1af8b3"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "statements": [
             {
               "idShort": "something_7cdc9635",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json
@@ -19,17 +19,7 @@
               "type": "ModelReference"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/valueType.json
@@ -40,17 +40,7 @@
             }
           ],
           "value": "10233",
-          "valueType": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "valueType": "Unexpected string value"
         }
       ],
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Key/type.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Key/type.json
@@ -8,17 +8,7 @@
       "derivedFrom": {
         "keys": [
           {
-            "type": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "type": "Unexpected string value",
             "value": "urn:an-example08:f3f73640"
           }
         ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json
@@ -84,17 +84,7 @@
               "text": "something_cd7e6587"
             }
           ],
-          "valueId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "valueId": "Unexpected string value"
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json
@@ -102,17 +102,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/OperationVariable/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/OperationVariable/value.json
@@ -8,17 +8,7 @@
           "idShort": "something3fdd3eb4",
           "inputVariables": [
             {
-              "value": [
-                {
-                  "keys": [
-                    {
-                      "type": "GlobalReference",
-                      "value": "unexpected instance"
-                    }
-                  ],
-                  "type": "ExternalReference"
-                }
-              ]
+              "value": "Unexpected string value"
             }
           ],
           "modelType": "Operation"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json
@@ -79,17 +79,7 @@
             }
           ],
           "value": "0061707",
-          "valueId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "valueId": "Unexpected string value",
           "valueType": "xs:decimal"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueType.json
@@ -88,17 +88,7 @@
             ],
             "type": "ModelReference"
           },
-          "valueType": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "valueType": "Unexpected string value"
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/kind.json
@@ -6,17 +6,7 @@
       "modelType": "Submodel",
       "qualifiers": [
         {
-          "kind": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "kind": "Unexpected string value",
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json
@@ -7,17 +7,7 @@
       "qualifiers": [
         {
           "kind": "TemplateQualifier",
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json
@@ -29,17 +29,7 @@
           ],
           "type": "something_5964ab43",
           "value": "001",
-          "valueId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "valueId": "Unexpected string value",
           "valueType": "xs:integer"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueType.json
@@ -38,17 +38,7 @@
             ],
             "type": "ModelReference"
           },
-          "valueType": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "valueType": "Unexpected string value"
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/valueType.json
@@ -79,17 +79,7 @@
               "type": "ModelReference"
             }
           ],
-          "valueType": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "valueType": "Unexpected string value"
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json
@@ -12,17 +12,7 @@
             "value": "urn:an-example08:f3f73640"
           }
         ],
-        "referredSemanticId": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ],
+        "referredSemanticId": "Unexpected string value",
         "type": "ModelReference"
       },
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/type.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/type.json
@@ -21,17 +21,7 @@
           ],
           "type": "ExternalReference"
         },
-        "type": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ]
+        "type": "Unexpected string value"
       },
       "id": "something_142922d6",
       "modelType": "AssetAdministrationShell"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json
@@ -78,17 +78,7 @@
               "type": "ModelReference"
             }
           ],
-          "value": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "value": "Unexpected string value"
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json
@@ -50,17 +50,7 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "first": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "first": "Unexpected string value",
           "idShort": "PiXO1wyHierj",
           "modelType": "RelationshipElement",
           "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json
@@ -67,17 +67,7 @@
               "valueType": "xs:long"
             }
           ],
-          "second": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "second": "Unexpected string value",
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json
@@ -76,17 +76,7 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json
@@ -5,17 +5,7 @@
         "assetKind": "NotApplicable",
         "specificAssetIds": [
           {
-            "externalSubjectId": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "externalSubjectId": "Unexpected string value",
             "name": "something_b0b6ce88",
             "semanticId": {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json
@@ -15,17 +15,7 @@
               "type": "ExternalReference"
             },
             "name": "something_b0b6ce88",
-            "semanticId": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "semanticId": "Unexpected string value",
             "supplementalSemanticIds": [
               {
                 "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json
@@ -1,17 +1,7 @@
 {
   "submodels": [
     {
-      "administration": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "administration": "Unexpected string value",
       "category": "something_91042c92",
       "description": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/kind.json
@@ -49,17 +49,7 @@
       ],
       "id": "something_48c66017",
       "idShort": "fiZ",
-      "kind": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "kind": "Unexpected string value",
       "modelType": "Submodel",
       "qualifiers": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json
@@ -57,17 +57,7 @@
           "valueType": "xs:int"
         }
       ],
-      "semanticId": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "semanticId": "Unexpected string value",
       "submodelElements": [
         {
           "first": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "semanticIdListElement": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json
@@ -68,17 +68,7 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticIdListElement": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticIdListElement": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/typeValueListElement.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/typeValueListElement.json
@@ -88,17 +88,7 @@
               "type": "ModelReference"
             }
           ],
-          "typeValueListElement": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "typeValueListElement": "Unexpected string value",
           "value": [
             {
               "entityType": "SelfManagedEntity",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/valueTypeListElement.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/valueTypeListElement.json
@@ -96,17 +96,7 @@
               "modelType": "Entity"
             }
           ],
-          "valueTypeListElement": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "valueTypeListElement": "Unexpected string value"
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json
@@ -32,17 +32,7 @@
               "valueReferencePairs": [
                 {
                   "value": "something_63781b6f",
-                  "valueId": [
-                    {
-                      "keys": [
-                        {
-                          "type": "GlobalReference",
-                          "value": "unexpected instance"
-                        }
-                      ],
-                      "type": "ExternalReference"
-                    }
-                  ]
+                  "valueId": "Unexpected string value"
                 }
               ]
             }

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json
@@ -1,15 +1,5 @@
 {
-  "observableReference": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "observableReference": "Unexpected string value",
   "observableSemanticId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json
@@ -8,17 +8,7 @@
     ],
     "type": "ModelReference"
   },
-  "observableSemanticId": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "observableSemanticId": "Unexpected string value",
   "payload": "/TsF2AbyQb1dIa0=",
   "source": {
     "keys": [

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json
@@ -18,17 +18,7 @@
     "type": "ModelReference"
   },
   "payload": "/TsF2AbyQb1dIa0=",
-  "source": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "source": "Unexpected string value",
   "sourceSemanticId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json
@@ -31,17 +31,7 @@
     ],
     "type": "ModelReference"
   },
-  "sourceSemanticId": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "sourceSemanticId": "Unexpected string value",
   "subjectId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json
@@ -40,17 +40,7 @@
     ],
     "type": "ModelReference"
   },
-  "subjectId": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "subjectId": "Unexpected string value",
   "timeStamp": "2022-04-01T24:00:00-00:00",
   "topic": "something_8f13d2dd"
 }

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/creator.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/administrativeInformation/creator.xml
@@ -32,17 +32,7 @@
 				</embeddedDataSpecifications>
 				<version>1230</version>
 				<revision>0</revision>
-				<creator>
-					<reference>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>unexpected instance</value>
-							</key>
-						</keys>
-					</reference>
-				</creator>
+				<creator>Unexpected string value</creator>
 				<templateId>something_cb08d136</templateId>
 			</administration>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/first.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/first.xml
@@ -77,17 +77,7 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<first>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</first>
+					<first>Unexpected string value</first>
 					<second>
 						<type>ExternalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/second.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/second.xml
@@ -86,17 +86,7 @@
 							</key>
 						</keys>
 					</first>
-					<second>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</second>
+					<second>Unexpected string value</second>
 					<annotations>
 						<multiLanguageProperty>
 							<idShort>something_41aa6b27</idShort>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/annotatedRelationshipElement/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/administration.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/administration.xml
@@ -20,17 +20,7 @@
 					<text>something_0c9e872c</text>
 				</langStringTextType>
 			</description>
-			<administration>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</administration>
+			<administration>Unexpected string value</administration>
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/assetInformation.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/assetInformation.xml
@@ -59,17 +59,7 @@
 					</key>
 				</keys>
 			</derivedFrom>
-			<assetInformation>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</assetInformation>
+			<assetInformation>Unexpected string value</assetInformation>
 			<submodels>
 				<reference>
 					<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/derivedFrom.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetAdministrationShell/derivedFrom.xml
@@ -50,17 +50,7 @@
 					</dataSpecificationContent>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
-			<derivedFrom>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</derivedFrom>
+			<derivedFrom>Unexpected string value</derivedFrom>
 			<assetInformation>
 				<assetKind>NotApplicable</assetKind>
 				<globalAssetId>something_eea66fa1</globalAssetId>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/assetKind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/assetKind.xml
@@ -3,17 +3,7 @@
 		<assetAdministrationShell>
 			<id>something_142922d6</id>
 			<assetInformation>
-				<assetKind>
-					<reference>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>unexpected instance</value>
-							</key>
-						</keys>
-					</reference>
-				</assetKind>
+				<assetKind>Unexpected string value</assetKind>
 				<globalAssetId>something_c71f0c8f</globalAssetId>
 				<assetType>something_9f4c5692</assetType>
 				<defaultThumbnail>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/defaultThumbnail.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/defaultThumbnail.xml
@@ -6,17 +6,7 @@
 				<assetKind>NotApplicable</assetKind>
 				<globalAssetId>something_c71f0c8f</globalAssetId>
 				<assetType>something_9f4c5692</assetType>
-				<defaultThumbnail>
-					<reference>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>unexpected instance</value>
-							</key>
-						</keys>
-					</reference>
-				</defaultThumbnail>
+				<defaultThumbnail>Unexpected string value</defaultThumbnail>
 			</assetInformation>
 		</assetAdministrationShell>
 	</assetAdministrationShells>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/direction.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/direction.xml
@@ -86,17 +86,7 @@
 							</key>
 						</keys>
 					</observed>
-					<direction>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</direction>
+					<direction>Unexpected string value</direction>
 					<state>off</state>
 					<messageTopic>something_99f1a7ac</messageTopic>
 					<messageBroker>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/messageBroker.xml
@@ -89,17 +89,7 @@
 					<direction>output</direction>
 					<state>off</state>
 					<messageTopic>something_99f1a7ac</messageTopic>
-					<messageBroker>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</messageBroker>
+					<messageBroker>Unexpected string value</messageBroker>
 					<lastUpdate>-3020-08-21T24:00:00.0Z</lastUpdate>
 					<minInterval>-P1Y</minInterval>
 					<maxInterval>PT130S</maxInterval>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/observed.xml
@@ -77,17 +77,7 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<observed>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</observed>
+					<observed>Unexpected string value</observed>
 					<direction>output</direction>
 					<state>off</state>
 					<messageTopic>something_99f1a7ac</messageTopic>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/state.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/state.xml
@@ -87,17 +87,7 @@
 						</keys>
 					</observed>
 					<direction>output</direction>
-					<state>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</state>
+					<state>Unexpected string value</state>
 					<messageTopic>something_99f1a7ac</messageTopic>
 					<messageBroker>
 						<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/blob/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/capability/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/conceptDescription/administration.xml
@@ -20,17 +20,7 @@
 					<text>something_863a162e</text>
 				</langStringTextType>
 			</description>
-			<administration>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</administration>
+			<administration>Unexpected string value</administration>
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/dataType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/dataType.xml
@@ -43,17 +43,7 @@
 							</unitId>
 							<sourceOfDefinition>something_1bd907c8</sourceOfDefinition>
 							<symbol>something_c13116d7</symbol>
-							<dataType>
-								<reference>
-									<type>ExternalReference</type>
-									<keys>
-										<key>
-											<type>GlobalReference</type>
-											<value>unexpected instance</value>
-										</key>
-									</keys>
-								</reference>
-							</dataType>
+							<dataType>Unexpected string value</dataType>
 							<definition>
 								<langStringDefinitionTypeIec61360>
 									<language>X-33DQI-g</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/levelType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/levelType.xml
@@ -52,17 +52,7 @@
 							</definition>
 							<valueFormat>something_f019e5a8</valueFormat>
 							<value>something_13759f45</value>
-							<levelType>
-								<reference>
-									<type>ExternalReference</type>
-									<keys>
-										<key>
-											<type>GlobalReference</type>
-											<value>unexpected instance</value>
-										</key>
-									</keys>
-								</reference>
-							</levelType>
+							<levelType>Unexpected string value</levelType>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
 				</embeddedDataSpecification>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unitId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/unitId.xml
@@ -32,17 +32,7 @@
 								</langStringShortNameTypeIec61360>
 							</shortName>
 							<unit>something_a6bd9450</unit>
-							<unitId>
-								<reference>
-									<type>ExternalReference</type>
-									<keys>
-										<key>
-											<type>GlobalReference</type>
-											<value>unexpected instance</value>
-										</key>
-									</keys>
-								</reference>
-							</unitId>
+							<unitId>Unexpected string value</unitId>
 							<sourceOfDefinition>something_1bd907c8</sourceOfDefinition>
 							<symbol>something_c13116d7</symbol>
 							<dataType>DATE</dataType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecification.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecification.xml
@@ -4,17 +4,7 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
-					<dataSpecification>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</dataSpecification>
+					<dataSpecification>Unexpected string value</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecificationContent.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/embeddedDataSpecification/dataSpecificationContent.xml
@@ -13,17 +13,7 @@
 							</key>
 						</keys>
 					</dataSpecification>
-					<dataSpecificationContent>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</dataSpecificationContent>
+					<dataSpecificationContent>Unexpected string value</dataSpecificationContent>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/entityType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/entityType.xml
@@ -83,17 +83,7 @@
 							<valueType>xs:gMonthDay</valueType>
 						</range>
 					</statements>
-					<entityType>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</entityType>
+					<entityType>Unexpected string value</entityType>
 				</entity>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/semanticId.xml
@@ -3,17 +3,7 @@
 		<assetAdministrationShell>
 			<extensions>
 				<extension>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ExternalReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/valueType.xml
@@ -24,17 +24,7 @@
 						</reference>
 					</supplementalSemanticIds>
 					<name>something_aae6caf4</name>
-					<valueType>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueType>
+					<valueType>Unexpected string value</valueType>
 					<value>10233</value>
 					<refersTo>
 						<reference>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/file/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/type.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/type.xml
@@ -6,17 +6,7 @@
 				<type>ModelReference</type>
 				<keys>
 					<key>
-						<type>
-							<reference>
-								<type>ExternalReference</type>
-								<keys>
-									<key>
-										<type>GlobalReference</type>
-										<value>unexpected instance</value>
-									</key>
-								</keys>
-							</reference>
-						</type>
+						<type>Unexpected string value</type>
 						<value>urn:an-example08:f3f73640</value>
 					</key>
 				</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/multiLanguageProperty/valueId.xml
@@ -83,17 +83,7 @@
 							<text>something_cd7e6587</text>
 						</langStringTextType>
 					</value>
-					<valueId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueId>
+					<valueId>Unexpected string value</valueId>
 				</multiLanguageProperty>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operation/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operationVariable/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/operationVariable/value.xml
@@ -7,17 +7,7 @@
 					<idShort>something3fdd3eb4</idShort>
 					<inputVariables>
 						<operationVariable>
-							<value>
-								<reference>
-									<type>ExternalReference</type>
-									<keys>
-										<key>
-											<type>GlobalReference</type>
-											<value>unexpected instance</value>
-										</key>
-									</keys>
-								</reference>
-							</value>
+							<value>Unexpected string value</value>
 						</operationVariable>
 					</inputVariables>
 				</operation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueId.xml
@@ -79,17 +79,7 @@
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>
 					<value>0061707</value>
-					<valueId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueId>
+					<valueId>Unexpected string value</valueId>
 				</property>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml
@@ -77,17 +77,7 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<valueType>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueType>
+					<valueType>Unexpected string value</valueType>
 					<value>0061707</value>
 					<valueId>
 						<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/kind.xml
@@ -25,17 +25,7 @@
 							</keys>
 						</reference>
 					</supplementalSemanticIds>
-					<kind>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</kind>
+					<kind>Unexpected string value</kind>
 					<type>something_5964ab43</type>
 					<valueType>xs:integer</valueType>
 					<value>001</value>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/semanticId.xml
@@ -5,17 +5,7 @@
 			<kind>Template</kind>
 			<qualifiers>
 				<qualifier>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ExternalReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueId.xml
@@ -29,17 +29,7 @@
 					<type>something_5964ab43</type>
 					<valueType>xs:integer</valueType>
 					<value>001</value>
-					<valueId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueId>
+					<valueId>Unexpected string value</valueId>
 				</qualifier>
 			</qualifiers>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueType.xml
@@ -27,17 +27,7 @@
 					</supplementalSemanticIds>
 					<kind>TemplateQualifier</kind>
 					<type>something_5964ab43</type>
-					<valueType>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueType>
+					<valueType>Unexpected string value</valueType>
 					<value>001</value>
 					<valueId>
 						<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml
@@ -77,17 +77,7 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<valueType>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueType>
+					<valueType>Unexpected string value</valueType>
 					<max>1234.1234567890123456789012345678901234567890123456789012345678901234567890</max>
 				</range>
 			</submodelElements>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/referredSemanticId.xml
@@ -4,17 +4,7 @@
 			<id>something_142922d6</id>
 			<derivedFrom>
 				<type>ModelReference</type>
-				<referredSemanticId>
-					<reference>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>unexpected instance</value>
-							</key>
-						</keys>
-					</reference>
-				</referredSemanticId>
+				<referredSemanticId>Unexpected string value</referredSemanticId>
 				<keys>
 					<key>
 						<type>AssetAdministrationShell</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/type.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/type.xml
@@ -3,17 +3,7 @@
 		<assetAdministrationShell>
 			<id>something_142922d6</id>
 			<derivedFrom>
-				<type>
-					<reference>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>unexpected instance</value>
-							</key>
-						</keys>
-					</reference>
-				</type>
+				<type>Unexpected string value</type>
 				<referredSemanticId>
 					<type>ExternalReference</type>
 					<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/referenceElement/value.xml
@@ -77,17 +77,7 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<value>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</value>
+					<value>Unexpected string value</value>
 				</referenceElement>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/first.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/first.xml
@@ -77,17 +77,7 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<first>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</first>
+					<first>Unexpected string value</first>
 					<second>
 						<type>ExternalReference</type>
 						<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/second.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/second.xml
@@ -86,17 +86,7 @@
 							</key>
 						</keys>
 					</first>
-					<second>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</second>
+					<second>Unexpected string value</second>
 				</relationshipElement>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/relationshipElement/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/externalSubjectId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/externalSubjectId.xml
@@ -28,17 +28,7 @@
 						</supplementalSemanticIds>
 						<name>something_b0b6ce88</name>
 						<value>something_a37abe43</value>
-						<externalSubjectId>
-							<reference>
-								<type>ExternalReference</type>
-								<keys>
-									<key>
-										<type>GlobalReference</type>
-										<value>unexpected instance</value>
-									</key>
-								</keys>
-							</reference>
-						</externalSubjectId>
+						<externalSubjectId>Unexpected string value</externalSubjectId>
 					</specificAssetId>
 				</specificAssetIds>
 			</assetInformation>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/specificAssetId/semanticId.xml
@@ -6,17 +6,7 @@
 				<assetKind>NotApplicable</assetKind>
 				<specificAssetIds>
 					<specificAssetId>
-						<semanticId>
-							<reference>
-								<type>ExternalReference</type>
-								<keys>
-									<key>
-										<type>GlobalReference</type>
-										<value>unexpected instance</value>
-									</key>
-								</keys>
-							</reference>
-						</semanticId>
+						<semanticId>Unexpected string value</semanticId>
 						<supplementalSemanticIds>
 							<reference>
 								<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/administration.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/administration.xml
@@ -20,17 +20,7 @@
 					<text>something_9a9e9635</text>
 				</langStringTextType>
 			</description>
-			<administration>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</administration>
+			<administration>Unexpected string value</administration>
 			<id>something_48c66017</id>
 			<kind>Instance</kind>
 			<semanticId>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/kind.xml
@@ -22,17 +22,7 @@
 			</description>
 			<administration/>
 			<id>something_48c66017</id>
-			<kind>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</kind>
+			<kind>Unexpected string value</kind>
 			<semanticId>
 				<type>ExternalReference</type>
 				<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/semanticId.xml
@@ -23,17 +23,7 @@
 			<administration/>
 			<id>something_48c66017</id>
 			<kind>Instance</kind>
-			<semanticId>
-				<reference>
-					<type>ExternalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>unexpected instance</value>
-						</key>
-					</keys>
-				</reference>
-			</semanticId>
+			<semanticId>Unexpected string value</semanticId>
 			<supplementalSemanticIds>
 				<reference>
 					<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementCollection/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticId.xml
@@ -23,17 +23,7 @@
 							<text>something_be9deae0</text>
 						</langStringTextType>
 					</description>
-					<semanticId>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticId>
+					<semanticId>Unexpected string value</semanticId>
 					<supplementalSemanticIds>
 						<reference>
 							<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticIdListElement.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/semanticIdListElement.xml
@@ -78,17 +78,7 @@
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>
-					<semanticIdListElement>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</semanticIdListElement>
+					<semanticIdListElement>Unexpected string value</semanticIdListElement>
 					<typeValueListElement>Entity</typeValueListElement>
 					<valueTypeListElement>xs:byte</valueTypeListElement>
 					<value>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/typeValueListElement.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/typeValueListElement.xml
@@ -87,17 +87,7 @@
 							</key>
 						</keys>
 					</semanticIdListElement>
-					<typeValueListElement>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</typeValueListElement>
+					<typeValueListElement>Unexpected string value</typeValueListElement>
 					<valueTypeListElement>xs:byte</valueTypeListElement>
 					<value>
 						<entity>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/valueTypeListElement.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/valueTypeListElement.xml
@@ -88,17 +88,7 @@
 						</keys>
 					</semanticIdListElement>
 					<typeValueListElement>Entity</typeValueListElement>
-					<valueTypeListElement>
-						<reference>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>unexpected instance</value>
-								</key>
-							</keys>
-						</reference>
-					</valueTypeListElement>
+					<valueTypeListElement>Unexpected string value</valueTypeListElement>
 					<value>
 						<entity>
 							<entityType>SelfManagedEntity</entityType>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/valueId.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/valueReferencePair/valueId.xml
@@ -29,17 +29,7 @@
 								<valueReferencePairs>
 									<valueReferencePair>
 										<value>something_63781b6f</value>
-										<valueId>
-											<reference>
-												<type>ExternalReference</type>
-												<keys>
-													<key>
-														<type>GlobalReference</type>
-														<value>unexpected instance</value>
-													</key>
-												</keys>
-											</reference>
-										</valueId>
+										<valueId>Unexpected string value</valueId>
 									</valueReferencePair>
 								</valueReferencePairs>
 							</valueList>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableReference.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableReference.xml
@@ -21,17 +21,7 @@
 			</key>
 		</keys>
 	</sourceSemanticId>
-	<observableReference>
-		<reference>
-			<type>ExternalReference</type>
-			<keys>
-				<key>
-					<type>GlobalReference</type>
-					<value>unexpected instance</value>
-				</key>
-			</keys>
-		</reference>
-	</observableReference>
+	<observableReference>Unexpected string value</observableReference>
 	<observableSemanticId>
 		<type>ModelReference</type>
 		<keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableSemanticId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/observableSemanticId.xml
@@ -30,17 +30,7 @@
 			</key>
 		</keys>
 	</observableReference>
-	<observableSemanticId>
-		<reference>
-			<type>ExternalReference</type>
-			<keys>
-				<key>
-					<type>GlobalReference</type>
-					<value>unexpected instance</value>
-				</key>
-			</keys>
-		</reference>
-	</observableSemanticId>
+	<observableSemanticId>Unexpected string value</observableSemanticId>
 	<topic>something_8f13d2dd</topic>
 	<subjectId>
 		<type>ExternalReference</type>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/source.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/source.xml
@@ -1,15 +1,5 @@
 <eventPayload xmlns="https://admin-shell.io/aas/3/0">
-	<source>
-		<reference>
-			<type>ExternalReference</type>
-			<keys>
-				<key>
-					<type>GlobalReference</type>
-					<value>unexpected instance</value>
-				</key>
-			</keys>
-		</reference>
-	</source>
+	<source>Unexpected string value</source>
 	<sourceSemanticId>
 		<type>ModelReference</type>
 		<keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/sourceSemanticId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/sourceSemanticId.xml
@@ -12,17 +12,7 @@
 			</key>
 		</keys>
 	</source>
-	<sourceSemanticId>
-		<reference>
-			<type>ExternalReference</type>
-			<keys>
-				<key>
-					<type>GlobalReference</type>
-					<value>unexpected instance</value>
-				</key>
-			</keys>
-		</reference>
-	</sourceSemanticId>
+	<sourceSemanticId>Unexpected string value</sourceSemanticId>
 	<observableReference>
 		<type>ModelReference</type>
 		<keys>

--- a/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/subjectId.xml
+++ b/test_data/Xml/SelfContained/Unexpected/TypeViolation/eventPayload/subjectId.xml
@@ -40,17 +40,7 @@
 		</keys>
 	</observableSemanticId>
 	<topic>something_8f13d2dd</topic>
-	<subjectId>
-		<reference>
-			<type>ExternalReference</type>
-			<keys>
-				<key>
-					<type>GlobalReference</type>
-					<value>unexpected instance</value>
-				</key>
-			</keys>
-		</reference>
-	</subjectId>
+	<subjectId>Unexpected string value</subjectId>
 	<timeStamp>2022-04-01T24:00:00-00:00</timeStamp>
 	<payload>/TsF2AbyQb1dIa0=</payload>
 </eventPayload>


### PR DESCRIPTION
We generated type violations as unexpected lists for non-lists, and strings for lists, respectively. This works well in JSON, but not is not so clear in XML. The lists in XML are serialized as a sequence of XML elements, which resembles also the serialization of the properties. Hence, when a list is passed in insteead of an atomic value, the first element in the list is interpreted as an invalid (additional, unexpected) property rather than list in XML.

With this change, we explicitly put a string where anything non-primitive is expected, and a reference where primitive values are expected. This way we make the type violations more explicit which in turn makes the debugging in the SDKs easier, since more meaningful errors are reported.