### PR TITLE
Make type violations explicit for enumerations

### DIFF
--- a/aas_core3_0_testgen/generation.py
+++ b/aas_core3_0_testgen/generation.py
@@ -820,7 +820,10 @@ def _generate_type_violations(maximal_case: CaseMaximal) -> Iterator[CaseTypeVio
 
         primitive_type = intermediate.try_primitive_type(type_anno)
 
-        if primitive_type is not None:
+        if primitive_type is not None or (
+            isinstance(type_anno, intermediate.OurTypeAnnotation)
+            and isinstance(type_anno.our_type, intermediate.Enumeration)
+        ):
             unexpected_instance, _ = preserialization.preserialize(
                 aas_types.Reference(
                     type=aas_types.ReferenceTypes.EXTERNAL_REFERENCE,

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/assetKind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/assetKind.json
@@ -2,7 +2,17 @@
   "assetAdministrationShells": [
     {
       "assetInformation": {
-        "assetKind": "Unexpected string value",
+        "assetKind": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ],
         "assetType": "something_9f4c5692",
         "defaultThumbnail": {
           "path": "file:/M5/%bA:'%9c%6b%ed%00Y*/%4C=4h:d:"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/direction.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/direction.json
@@ -12,7 +12,17 @@
               "text": "something_be9deae0"
             }
           ],
-          "direction": "Unexpected string value",
+          "direction": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "displayName": [
             {
               "language": "Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/state.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/state.json
@@ -90,7 +90,17 @@
             ],
             "type": "ExternalReference"
           },
-          "state": "Unexpected string value",
+          "state": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/dataType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/dataType.json
@@ -17,7 +17,17 @@
             "type": "ExternalReference"
           },
           "dataSpecificationContent": {
-            "dataType": "Unexpected string value",
+            "dataType": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "definition": [
               {
                 "language": "X-33DQI-g",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/entityType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/entityType.json
@@ -45,7 +45,17 @@
               }
             }
           ],
-          "entityType": "Unexpected string value",
+          "entityType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "extensions": [
             {
               "name": "something_aa1af8b3"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/valueType.json
@@ -40,7 +40,17 @@
             }
           ],
           "value": "10233",
-          "valueType": "Unexpected string value"
+          "valueType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ],
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Key/type.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Key/type.json
@@ -8,7 +8,17 @@
       "derivedFrom": {
         "keys": [
           {
-            "type": "Unexpected string value",
+            "type": [
+              {
+                "keys": [
+                  {
+                    "type": "GlobalReference",
+                    "value": "unexpected instance"
+                  }
+                ],
+                "type": "ExternalReference"
+              }
+            ],
             "value": "urn:an-example08:f3f73640"
           }
         ],

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueType.json
@@ -88,7 +88,17 @@
             ],
             "type": "ModelReference"
           },
-          "valueType": "Unexpected string value"
+          "valueType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/kind.json
@@ -6,7 +6,17 @@
       "modelType": "Submodel",
       "qualifiers": [
         {
-          "kind": "Unexpected string value",
+          "kind": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueType.json
@@ -38,7 +38,17 @@
             ],
             "type": "ModelReference"
           },
-          "valueType": "Unexpected string value"
+          "valueType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/valueType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/valueType.json
@@ -79,7 +79,17 @@
               "type": "ModelReference"
             }
           ],
-          "valueType": "Unexpected string value"
+          "valueType": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/type.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/type.json
@@ -21,7 +21,17 @@
           ],
           "type": "ExternalReference"
         },
-        "type": "Unexpected string value"
+        "type": [
+          {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "unexpected instance"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        ]
       },
       "id": "something_142922d6",
       "modelType": "AssetAdministrationShell"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/kind.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/kind.json
@@ -49,7 +49,17 @@
       ],
       "id": "something_48c66017",
       "idShort": "fiZ",
-      "kind": "Unexpected string value",
+      "kind": [
+        {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "unexpected instance"
+            }
+          ],
+          "type": "ExternalReference"
+        }
+      ],
       "modelType": "Submodel",
       "qualifiers": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/typeValueListElement.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/typeValueListElement.json
@@ -88,7 +88,17 @@
               "type": "ModelReference"
             }
           ],
-          "typeValueListElement": "Unexpected string value",
+          "typeValueListElement": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ],
           "value": [
             {
               "entityType": "SelfManagedEntity",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/valueTypeListElement.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/valueTypeListElement.json
@@ -96,7 +96,17 @@
               "modelType": "Entity"
             }
           ],
-          "valueTypeListElement": "Unexpected string value"
+          "valueTypeListElement": [
+            {
+              "keys": [
+                {
+                  "type": "GlobalReference",
+                  "value": "unexpected instance"
+                }
+              ],
+              "type": "ExternalReference"
+            }
+          ]
         }
       ]
     }

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/assetKind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/assetInformation/assetKind.xml
@@ -3,7 +3,17 @@
 		<assetAdministrationShell>
 			<id>something_142922d6</id>
 			<assetInformation>
-				<assetKind>Unexpected string value</assetKind>
+				<assetKind>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</assetKind>
 				<globalAssetId>something_c71f0c8f</globalAssetId>
 				<assetType>something_9f4c5692</assetType>
 				<defaultThumbnail>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/direction.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/direction.xml
@@ -86,7 +86,17 @@
 							</key>
 						</keys>
 					</observed>
-					<direction>Unexpected string value</direction>
+					<direction>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</direction>
 					<state>off</state>
 					<messageTopic>something_99f1a7ac</messageTopic>
 					<messageBroker>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/state.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/basicEventElement/state.xml
@@ -87,7 +87,17 @@
 						</keys>
 					</observed>
 					<direction>output</direction>
-					<state>Unexpected string value</state>
+					<state>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</state>
 					<messageTopic>something_99f1a7ac</messageTopic>
 					<messageBroker>
 						<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/dataType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/dataSpecificationIec61360/dataType.xml
@@ -43,7 +43,17 @@
 							</unitId>
 							<sourceOfDefinition>something_1bd907c8</sourceOfDefinition>
 							<symbol>something_c13116d7</symbol>
-							<dataType>Unexpected string value</dataType>
+							<dataType>
+								<reference>
+									<type>ExternalReference</type>
+									<keys>
+										<key>
+											<type>GlobalReference</type>
+											<value>unexpected instance</value>
+										</key>
+									</keys>
+								</reference>
+							</dataType>
 							<definition>
 								<langStringDefinitionTypeIec61360>
 									<language>X-33DQI-g</language>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/entityType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/entity/entityType.xml
@@ -83,7 +83,17 @@
 							<valueType>xs:gMonthDay</valueType>
 						</range>
 					</statements>
-					<entityType>Unexpected string value</entityType>
+					<entityType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</entityType>
 				</entity>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/valueType.xml
@@ -24,7 +24,17 @@
 						</reference>
 					</supplementalSemanticIds>
 					<name>something_aae6caf4</name>
-					<valueType>Unexpected string value</valueType>
+					<valueType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueType>
 					<value>10233</value>
 					<refersTo>
 						<reference>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/type.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/key/type.xml
@@ -6,7 +6,17 @@
 				<type>ModelReference</type>
 				<keys>
 					<key>
-						<type>Unexpected string value</type>
+						<type>
+							<reference>
+								<type>ExternalReference</type>
+								<keys>
+									<key>
+										<type>GlobalReference</type>
+										<value>unexpected instance</value>
+									</key>
+								</keys>
+							</reference>
+						</type>
 						<value>urn:an-example08:f3f73640</value>
 					</key>
 				</keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<valueType>Unexpected string value</valueType>
+					<valueType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueType>
 					<value>0061707</value>
 					<valueId>
 						<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/kind.xml
@@ -25,7 +25,17 @@
 							</keys>
 						</reference>
 					</supplementalSemanticIds>
-					<kind>Unexpected string value</kind>
+					<kind>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</kind>
 					<type>something_5964ab43</type>
 					<valueType>xs:integer</valueType>
 					<value>001</value>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueType.xml
@@ -27,7 +27,17 @@
 					</supplementalSemanticIds>
 					<kind>TemplateQualifier</kind>
 					<type>something_5964ab43</type>
-					<valueType>Unexpected string value</valueType>
+					<valueType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueType>
 					<value>001</value>
 					<valueId>
 						<type>ModelReference</type>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml
@@ -77,7 +77,17 @@
 							</dataSpecificationContent>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
-					<valueType>Unexpected string value</valueType>
+					<valueType>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueType>
 					<max>1234.1234567890123456789012345678901234567890123456789012345678901234567890</max>
 				</range>
 			</submodelElements>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/type.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/reference/type.xml
@@ -3,7 +3,17 @@
 		<assetAdministrationShell>
 			<id>something_142922d6</id>
 			<derivedFrom>
-				<type>Unexpected string value</type>
+				<type>
+					<reference>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>unexpected instance</value>
+							</key>
+						</keys>
+					</reference>
+				</type>
 				<referredSemanticId>
 					<type>ExternalReference</type>
 					<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/kind.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodel/kind.xml
@@ -22,7 +22,17 @@
 			</description>
 			<administration/>
 			<id>something_48c66017</id>
-			<kind>Unexpected string value</kind>
+			<kind>
+				<reference>
+					<type>ExternalReference</type>
+					<keys>
+						<key>
+							<type>GlobalReference</type>
+							<value>unexpected instance</value>
+						</key>
+					</keys>
+				</reference>
+			</kind>
 			<semanticId>
 				<type>ExternalReference</type>
 				<keys>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/typeValueListElement.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/typeValueListElement.xml
@@ -87,7 +87,17 @@
 							</key>
 						</keys>
 					</semanticIdListElement>
-					<typeValueListElement>Unexpected string value</typeValueListElement>
+					<typeValueListElement>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</typeValueListElement>
 					<valueTypeListElement>xs:byte</valueTypeListElement>
 					<value>
 						<entity>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/valueTypeListElement.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/valueTypeListElement.xml
@@ -88,7 +88,17 @@
 						</keys>
 					</semanticIdListElement>
 					<typeValueListElement>Entity</typeValueListElement>
-					<valueTypeListElement>Unexpected string value</valueTypeListElement>
+					<valueTypeListElement>
+						<reference>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>unexpected instance</value>
+								</key>
+							</keys>
+						</reference>
+					</valueTypeListElement>
 					<value>
 						<entity>
 							<entityType>SelfManagedEntity</entityType>


### PR DESCRIPTION
In #12, we made type violations explicit for non-primitives. However, for enumerations, the type violations are now misinterpreted as invalid enumeration literals, as enumerations in JSON and XML are represented as strings.

In this patch, we generate type violations for enumerations as unexpected instances to avoid confusion due to uninformative messages reported from the SDKs.