### PR TITLE
Fix more positive fuzzings for double

### DIFF
--- a/aas_core3_0_testgen/frozen_examples/xs_value.py
+++ b/aas_core3_0_testgen/frozen_examples/xs_value.py
@@ -382,7 +382,7 @@ BY_VALUE_TYPE: Mapping[str, Examples] = collections.OrderedDict(
                         ("fuzzed_06", "+76E-86"),
                         ("fuzzed_07", "-.662"),
                         ("fuzzed_08", "1e+7"),
-                        ("fuzzed_09", "-.66E-452289"),
+                        ("fuzzed_09", "-.66E-45"),
                         ("fuzzed_10", "140206134"),
                     ]
                 ),

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_09.json
@@ -8,7 +8,7 @@
       "extensions": [
         {
           "name": "something_aae6caf4",
-          "value": "-.66E-452289",
+          "value": "-.66E-45",
           "valueType": "xs:double"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_09.json
@@ -7,7 +7,7 @@
         {
           "idShort": "something3fdd3eb4",
           "modelType": "Property",
-          "value": "-.66E-452289",
+          "value": "-.66E-45",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_09.json
@@ -6,7 +6,7 @@
       "qualifiers": [
         {
           "type": "something_5964ab43",
-          "value": "-.66E-452289",
+          "value": "-.66E-45",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_09.json
@@ -6,8 +6,8 @@
       "submodelElements": [
         {
           "idShort": "something3fdd3eb4",
-          "max": "-.66E-452289",
-          "min": "-.66E-452289",
+          "max": "-.66E-45",
+          "min": "-.66E-45",
           "modelType": "Range",
           "valueType": "xs:double"
         }

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_09.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_09.ttl
@@ -9,7 +9,7 @@
         rdf:type aas:Extension ;
         <https://admin-shell.io/aas/3/0/Extension/name> "something_aae6caf4"^^xs:string ;
         <https://admin-shell.io/aas/3/0/Extension/valueType> <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Double> ;
-        <https://admin-shell.io/aas/3/0/Extension/value> "-.66E-452289"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/Extension/value> "-.66E-45"^^xs:string ;
     ] ;
     <https://admin-shell.io/aas/3/0/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/0/AssetAdministrationShell/assetInformation> [

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_09.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_09.ttl
@@ -10,6 +10,6 @@
         rdf:type aas:Property ;
         <https://admin-shell.io/aas/3/0/Referable/idShort> "something3fdd3eb4"^^xs:string ;
         <https://admin-shell.io/aas/3/0/Property/valueType> <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Double> ;
-        <https://admin-shell.io/aas/3/0/Property/value> "-.66E-452289"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/Property/value> "-.66E-45"^^xs:string ;
     ] ;
 .

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_09.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_09.ttl
@@ -10,6 +10,6 @@
         rdf:type aas:Qualifier ;
         <https://admin-shell.io/aas/3/0/Qualifier/type> "something_5964ab43"^^xs:string ;
         <https://admin-shell.io/aas/3/0/Qualifier/valueType> <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Double> ;
-        <https://admin-shell.io/aas/3/0/Qualifier/value> "-.66E-452289"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/Qualifier/value> "-.66E-45"^^xs:string ;
     ] ;
 .

--- a/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_09.ttl
+++ b/test_data/Rdf/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_09.ttl
@@ -10,7 +10,7 @@
         rdf:type aas:Range ;
         <https://admin-shell.io/aas/3/0/Referable/idShort> "something3fdd3eb4"^^xs:string ;
         <https://admin-shell.io/aas/3/0/Range/valueType> <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Double> ;
-        <https://admin-shell.io/aas/3/0/Range/min> "-.66E-452289"^^xs:string ;
-        <https://admin-shell.io/aas/3/0/Range/max> "-.66E-452289"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/Range/min> "-.66E-45"^^xs:string ;
+        <https://admin-shell.io/aas/3/0/Range/max> "-.66E-45"^^xs:string ;
     ] ;
 .

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Double/fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Double/fuzzed_09.xml
@@ -5,7 +5,7 @@
 				<extension>
 					<name>something_aae6caf4</name>
 					<valueType>xs:double</valueType>
-					<value>-.66E-452289</value>
+					<value>-.66E-45</value>
 				</extension>
 			</extensions>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Double/fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Double/fuzzed_09.xml
@@ -6,7 +6,7 @@
 				<property>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:double</valueType>
-					<value>-.66E-452289</value>
+					<value>-.66E-45</value>
 				</property>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Double/fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Double/fuzzed_09.xml
@@ -6,7 +6,7 @@
 				<qualifier>
 					<type>something_5964ab43</type>
 					<valueType>xs:double</valueType>
-					<value>-.66E-452289</value>
+					<value>-.66E-45</value>
 				</qualifier>
 			</qualifiers>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Double/fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Double/fuzzed_09.xml
@@ -6,8 +6,8 @@
 				<range>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:double</valueType>
-					<min>-.66E-452289</min>
-					<max>-.66E-452289</max>
+					<min>-.66E-45</min>
+					<max>-.66E-45</max>
 				</range>
 			</submodelElements>
 		</submodel>


### PR DESCRIPTION
Further testing revelead that another positive example value for `xs:double` was incorrect, *i.e.*, out-of-range.

In this patch, we fix all the relevant examples.