### PR TITLE
Change generate scripts to use path arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,4 @@ dmypy.json
 .pyre/
 
 # PyCharm
-.idea
+.idea/

--- a/aas_core3_0_testgen/common.py
+++ b/aas_core3_0_testgen/common.py
@@ -17,7 +17,6 @@ from typing import (
 import aas_core_codegen.common
 import aas_core_codegen.parse
 import aas_core_codegen.run
-import aas_core_meta.v3
 from aas_core_codegen import intermediate, infer_for_schema
 from icontract import ensure
 from typing_extensions import assert_never
@@ -25,7 +24,9 @@ from typing_extensions import assert_never
 import aas_core3.types as aas_types
 
 
-def load_symbol_table_and_infer_constraints_for_schema() -> Tuple[
+def load_symbol_table_and_infer_constraints_for_schema(
+    model_path: pathlib.Path,
+) -> Tuple[
     intermediate.SymbolTable,
     MutableMapping[intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty],
 ]:
@@ -37,7 +38,6 @@ def load_symbol_table_and_infer_constraints_for_schema() -> Tuple[
     in the schema constraints. However, this will help us cover *many* classes of the
     meta-model and spare us the work of manually writing many generators.
     """
-    model_path = pathlib.Path(aas_core_meta.v3.__file__)
     assert model_path.exists() and model_path.is_file(), model_path
 
     text = model_path.read_text(encoding="utf-8")

--- a/aas_core3_0_testgen/frozen_examples/pattern.py
+++ b/aas_core3_0_testgen/frozen_examples/pattern.py
@@ -10,9 +10,8 @@ automatically fuzz the patterns on-the-fly.
 import collections
 from typing import Mapping, MutableMapping, List
 
-from aas_core_codegen import intermediate
+from aas_core_codegen import intermediate, infer_for_schema
 
-from aas_core3_0_testgen import common
 from aas_core3_0_testgen.frozen_examples._types import Examples
 
 # noinspection SpellCheckingInspection
@@ -472,13 +471,13 @@ BY_PATTERN: Mapping[str, Examples] = collections.OrderedDict(
 )
 
 
-def _assert_all_pattern_verification_functions_covered_and_not_more() -> None:
+def assert_all_pattern_verification_functions_covered_and_not_more(
+    symbol_table: intermediate.SymbolTable,
+    constraints_by_class: Mapping[
+        intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
+    ],
+) -> None:
     """Assert that we have some pattern for each pattern verification function."""
-    (
-        symbol_table,
-        constraints_by_class,
-    ) = common.load_symbol_table_and_infer_constraints_for_schema()
-
     expected = {
         verification.pattern
         for verification in symbol_table.verification_functions
@@ -531,6 +530,3 @@ def _assert_all_pattern_verification_functions_covered_and_not_more() -> None:
             f"The following patterns could not be traced back to "
             f"any pattern verification function: {surplus}"
         )
-
-
-_assert_all_pattern_verification_functions_covered_and_not_more()

--- a/aas_core3_0_testgen/frozen_examples/xs_value.py
+++ b/aas_core3_0_testgen/frozen_examples/xs_value.py
@@ -3,6 +3,8 @@ import collections
 from typing import Mapping
 
 import aas_core_meta.v3
+from aas_core_codegen import intermediate
+from aas_core_codegen.common import Identifier
 
 from aas_core3_0_testgen.frozen_examples._types import Examples
 
@@ -1360,11 +1362,15 @@ BY_VALUE_TYPE: Mapping[str, Examples] = collections.OrderedDict(
 )
 
 
-def _assert_all_covered_and_not_more() -> None:
+def assert_all_covered_and_not_more(symbol_table: intermediate.SymbolTable) -> None:
     """Assert that we covered all the XSD data types."""
     covered = set(BY_VALUE_TYPE.keys())
 
-    literal_values = {literal.value for literal in aas_core_meta.v3.Data_type_def_XSD}
+    data_type_def_xsd = symbol_table.must_find_enumeration(
+        name=Identifier("Data_type_def_XSD")
+    )
+
+    literal_values = {literal.value for literal in data_type_def_xsd.literals}
 
     not_covered = sorted(literal_values.difference(covered))
     surplus = sorted(covered.difference(literal_values))
@@ -1380,6 +1386,3 @@ def _assert_all_covered_and_not_more() -> None:
             f"The following keys in BY_VALUE_TYPE were not present in "
             f"{aas_core_meta.v3.Data_type_def_XSD.__name__} literals: {surplus}"
         )
-
-
-_assert_all_covered_and_not_more()

--- a/aas_core3_0_testgen/generate_all.py
+++ b/aas_core3_0_testgen/generate_all.py
@@ -1,7 +1,6 @@
 """Generate all the test data."""
 
 import argparse
-import os
 import pathlib
 import sys
 
@@ -13,14 +12,26 @@ import aas_core3_0_testgen.generate_xml
 def main() -> int:
     """Execute the main routine."""
     parser = argparse.ArgumentParser(description=__doc__)
-    _ = parser.parse_args()
+    parser.add_argument("--model_path", help="path to the meta-model", required=True)
+    parser.add_argument(
+        "--test_data_dir",
+        help="path to the directory where the generated data resides",
+        required=True,
+    )
+    args = parser.parse_args()
 
-    this_path = pathlib.Path(os.path.realpath(__file__))
-    test_data_dir = this_path.parent.parent / "test_data"
+    model_path = pathlib.Path(args.model_path)
+    test_data_dir = pathlib.Path(args.test_data_dir)
 
-    aas_core3_0_testgen.generate_json.generate(test_data_dir=test_data_dir)
-    aas_core3_0_testgen.generate_rdf.generate(test_data_dir=test_data_dir)
-    aas_core3_0_testgen.generate_xml.generate(test_data_dir=test_data_dir)
+    aas_core3_0_testgen.generate_json.generate(
+        model_path=model_path, test_data_dir=test_data_dir
+    )
+    aas_core3_0_testgen.generate_rdf.generate(
+        model_path=model_path, test_data_dir=test_data_dir
+    )
+    aas_core3_0_testgen.generate_xml.generate(
+        model_path=model_path, test_data_dir=test_data_dir
+    )
 
     return 0
 

--- a/aas_core3_0_testgen/generate_json.py
+++ b/aas_core3_0_testgen/generate_json.py
@@ -1,9 +1,9 @@
 """Generate test data in JSON for the meta-model V3aas-core3.0-testgen."""
+import argparse
 import base64
 import collections
 import collections.abc
 import json
-import os
 import pathlib
 from typing import (
     Union,
@@ -263,12 +263,12 @@ def dereference(
     return cursor
 
 
-def generate(test_data_dir: pathlib.Path) -> None:
+def generate(model_path: pathlib.Path, test_data_dir: pathlib.Path) -> None:
     """Generate the JSON files."""
     (
         symbol_table,
         constraints_by_class,
-    ) = common.load_symbol_table_and_infer_constraints_for_schema()
+    ) = common.load_symbol_table_and_infer_constraints_for_schema(model_path=model_path)
 
     serializer = _Serializer(symbol_table=symbol_table)
 
@@ -292,10 +292,19 @@ def generate(test_data_dir: pathlib.Path) -> None:
 
 def main() -> None:
     """Execute the main routine."""
-    this_path = pathlib.Path(os.path.realpath(__file__))
-    test_data_dir = this_path.parent.parent / "test_data"
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", help="path to the meta-model", required=True)
+    parser.add_argument(
+        "--test_data_dir",
+        help="path to the directory where the generated data resides",
+        required=True,
+    )
+    args = parser.parse_args()
 
-    generate(test_data_dir=test_data_dir)
+    model_path = pathlib.Path(args.model_path)
+    test_data_dir = pathlib.Path(args.test_data_dir)
+
+    generate(model_path=model_path, test_data_dir=test_data_dir)
 
 
 if __name__ == "__main__":

--- a/aas_core3_0_testgen/generate_rdf.py
+++ b/aas_core3_0_testgen/generate_rdf.py
@@ -1,7 +1,7 @@
 """Generate test data in RDF for the meta-model V3aas-core3.0-testgen."""
+import argparse
 import base64
 import io
-import os
 import pathlib
 import textwrap
 import urllib.parse
@@ -469,12 +469,12 @@ def _serialize_property(
     raise AssertionError("Unexpected execution path")
 
 
-def generate(test_data_dir: pathlib.Path) -> None:
+def generate(model_path: pathlib.Path, test_data_dir: pathlib.Path) -> None:
     """Generate the XML files."""
     (
         symbol_table,
         constraints_by_class,
-    ) = common.load_symbol_table_and_infer_constraints_for_schema()
+    ) = common.load_symbol_table_and_infer_constraints_for_schema(model_path=model_path)
 
     identifiable_cls = symbol_table.must_find_abstract_class(Identifier("Identifiable"))
 
@@ -556,10 +556,19 @@ def generate(test_data_dir: pathlib.Path) -> None:
 
 def main() -> None:
     """Execute the main routine."""
-    this_path = pathlib.Path(os.path.realpath(__file__))
-    test_data_dir = this_path.parent.parent / "test_data"
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", help="path to the meta-model", required=True)
+    parser.add_argument(
+        "--test_data_dir",
+        help="path to the directory where the generated data resides",
+        required=True,
+    )
+    args = parser.parse_args()
 
-    generate(test_data_dir=test_data_dir)
+    model_path = pathlib.Path(args.model_path)
+    test_data_dir = pathlib.Path(args.test_data_dir)
+
+    generate(model_path=model_path, test_data_dir=test_data_dir)
 
 
 if __name__ == "__main__":

--- a/aas_core3_0_testgen/generate_xml.py
+++ b/aas_core3_0_testgen/generate_xml.py
@@ -1,7 +1,7 @@
 """Generate test data in XML for the meta-model V3aas-core3.0-testgen."""
+import argparse
 import base64
 import math
-import os
 import pathlib
 import re
 from typing import (
@@ -342,12 +342,12 @@ class _Serializer:
         return sequence
 
 
-def generate(test_data_dir: pathlib.Path) -> None:
+def generate(model_path: pathlib.Path, test_data_dir: pathlib.Path) -> None:
     """Generate the XML files."""
     (
         symbol_table,
         constraints_by_class,
-    ) = common.load_symbol_table_and_infer_constraints_for_schema()
+    ) = common.load_symbol_table_and_infer_constraints_for_schema(model_path=model_path)
 
     serializer = _Serializer(symbol_table=symbol_table)
 
@@ -385,10 +385,19 @@ def generate(test_data_dir: pathlib.Path) -> None:
 
 def main() -> None:
     """Execute the main routine."""
-    this_path = pathlib.Path(os.path.realpath(__file__))
-    test_data_dir = this_path.parent.parent / "test_data"
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", help="path to the meta-model", required=True)
+    parser.add_argument(
+        "--test_data_dir",
+        help="path to the directory where the generated data resides",
+        required=True,
+    )
+    args = parser.parse_args()
 
-    generate(test_data_dir=test_data_dir)
+    model_path = pathlib.Path(args.model_path)
+    test_data_dir = pathlib.Path(args.test_data_dir)
+
+    generate(model_path=model_path, test_data_dir=test_data_dir)
 
 
 if __name__ == "__main__":

--- a/aas_core3_0_testgen/generation.py
+++ b/aas_core3_0_testgen/generation.py
@@ -2652,6 +2652,12 @@ def generate(
     ],
 ) -> Iterator[CaseUnion]:
     """Generate the test cases."""
+    frozen_examples_pattern.assert_all_pattern_verification_functions_covered_and_not_more(
+        symbol_table=symbol_table, constraints_by_class=constraints_by_class
+    )
+
+    frozen_examples_xs_value.assert_all_covered_and_not_more(symbol_table=symbol_table)
+
     environment_cls = EnvironmentClass(
         symbol_table.must_find_concrete_class(Identifier("Environment"))
     )

--- a/dev_scripts/codegen/generate_all.py
+++ b/dev_scripts/codegen/generate_all.py
@@ -1,6 +1,8 @@
 """Generate all the code for the test gen."""
 
 import argparse
+import os
+import pathlib
 import sys
 
 import dev_scripts.codegen.generate_creation
@@ -11,25 +13,44 @@ import dev_scripts.codegen.generate_abstract_fixing
 
 def main() -> int:
     """Execute the main routine."""
+    repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
+
     parser = argparse.ArgumentParser(description=__doc__)
-    _ = parser.parse_args()
+    parser.add_argument("--model_path", help="path to the meta-model", required=True)
+    parser.add_argument(
+        "--codegened_dir",
+        help="path to the directory containing the generated code",
+        default=str(repo_dir / "aas_core3_0_testgen" / "codegened"),
+    )
+    args = parser.parse_args()
 
-    error = dev_scripts.codegen.generate_creation.generate_and_write()
+    model_path = pathlib.Path(args.model_path)
+    codegened_dir = pathlib.Path(args.codegened_dir)
+
+    error = dev_scripts.codegen.generate_creation.generate_and_write(
+        model_path=model_path, codegened_dir=codegened_dir
+    )
     if error is not None:
         print(f"Failed to generate creation: {error}", file=sys.stderr)
         return 1
 
-    error = dev_scripts.codegen.generate_wrapping.generate_and_write()
+    error = dev_scripts.codegen.generate_wrapping.generate_and_write(
+        model_path=model_path, codegened_dir=codegened_dir
+    )
     if error is not None:
         print(f"Failed to generate creation: {error}", file=sys.stderr)
         return 1
 
-    error = dev_scripts.codegen.generate_preserialization.generate_and_write()
+    error = dev_scripts.codegen.generate_preserialization.generate_and_write(
+        model_path=model_path, codegened_dir=codegened_dir
+    )
     if error is not None:
         print(f"Failed to generate creation: {error}", file=sys.stderr)
         return 1
 
-    error = dev_scripts.codegen.generate_abstract_fixing.generate_and_write()
+    error = dev_scripts.codegen.generate_abstract_fixing.generate_and_write(
+        model_path=model_path, codegened_dir=codegened_dir
+    )
     if error is not None:
         print(f"Failed to generate creation: {error}", file=sys.stderr)
         return 1

--- a/dev_scripts/codegen/generate_creation.py
+++ b/dev_scripts/codegen/generate_creation.py
@@ -1059,9 +1059,6 @@ def exact_concrete_maximal(
     )
 
 
-_REPO_DIR = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
-
-
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _generate(
     symbol_table: intermediate.SymbolTable,
@@ -1175,11 +1172,15 @@ from aas_core3 import types as aas_types"""
     return Stripped("\n\n\n".join(blocks)), None
 
 
-def generate_and_write() -> Optional[str]:
+def generate_and_write(
+    model_path: pathlib.Path, codegened_dir: pathlib.Path
+) -> Optional[str]:
     """Generate the code and write it to the pre-defined file."""
     # fmt: off
     symbol_table, constraints_by_class = (
-        aas_core3_0_testgen.common.load_symbol_table_and_infer_constraints_for_schema()
+        aas_core3_0_testgen.common.load_symbol_table_and_infer_constraints_for_schema(
+            model_path=model_path
+        )
     )
     # fmt: on
 
@@ -1189,7 +1190,7 @@ def generate_and_write() -> Optional[str]:
 
     assert code is not None
 
-    path = _REPO_DIR / "aas_core3_0_testgen" / "codegened" / "creation.py"
+    path = codegened_dir / "creation.py"
     path.write_text(code + "\n", encoding="utf-8")
 
     return None
@@ -1197,10 +1198,21 @@ def generate_and_write() -> Optional[str]:
 
 def main() -> int:
     """Execute the main routine."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    _ = parser.parse_args()
+    repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
 
-    error = generate_and_write()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", help="path to the meta-model", required=True)
+    parser.add_argument(
+        "--codegened_dir",
+        help="path to the directory containing the generated code",
+        default=str(repo_dir / "aas_core3_0_testgen" / "codegened"),
+    )
+    args = parser.parse_args()
+
+    model_path = pathlib.Path(args.model_path)
+    codegened_dir = pathlib.Path(args.codegened_dir)
+
+    error = generate_and_write(model_path=model_path, codegened_dir=codegened_dir)
     if error is not None:
         print(error, file=sys.stderr)
         return 1

--- a/dev_scripts/codegen/generate_preserialization.py
+++ b/dev_scripts/codegen/generate_preserialization.py
@@ -21,8 +21,6 @@ import aas_core3_0_testgen.common
 import dev_scripts.codegen.common
 import dev_scripts.codegen.ontology
 
-_REPO_DIR = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
-
 
 def _generate_preserialization_classes() -> List[Stripped]:
     """Generate the classes representing the pre-serialization."""
@@ -340,11 +338,15 @@ def preserialize(
     return Stripped("\n\n\n".join(blocks)), None
 
 
-def generate_and_write() -> Optional[str]:
+def generate_and_write(
+    model_path: pathlib.Path, codegened_dir: pathlib.Path
+) -> Optional[str]:
     """Generate the code and write it to the pre-defined file."""
     # fmt: off
     symbol_table, _ = (
-        aas_core3_0_testgen.common.load_symbol_table_and_infer_constraints_for_schema()
+        aas_core3_0_testgen.common.load_symbol_table_and_infer_constraints_for_schema(
+            model_path=model_path
+        )
     )
     # fmt: on
 
@@ -354,7 +356,7 @@ def generate_and_write() -> Optional[str]:
 
     assert code is not None
 
-    path = _REPO_DIR / "aas_core3_0_testgen" / "codegened" / "preserialization.py"
+    path = codegened_dir / "preserialization.py"
     path.write_text(code + "\n", encoding="utf-8")
 
     return None
@@ -362,10 +364,21 @@ def generate_and_write() -> Optional[str]:
 
 def main() -> int:
     """Execute the main routine."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    _ = parser.parse_args()
+    repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
 
-    error = generate_and_write()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", help="path to the meta-model", required=True)
+    parser.add_argument(
+        "--codegened_dir",
+        help="path to the directory containing the generated code",
+        default=str(repo_dir / "aas_core3_0_testgen" / "codegened"),
+    )
+    args = parser.parse_args()
+
+    model_path = pathlib.Path(args.model_path)
+    codegened_dir = pathlib.Path(args.codegened_dir)
+
+    error = generate_and_write(model_path=model_path, codegened_dir=codegened_dir)
     if error is not None:
         print(error, file=sys.stderr)
         return 1

--- a/dev_scripts/codegen/generate_wrapping.py
+++ b/dev_scripts/codegen/generate_wrapping.py
@@ -535,11 +535,15 @@ def lives_in_environment(
     return Stripped("\n\n\n".join(blocks)), None
 
 
-def generate_and_write() -> Optional[str]:
+def generate_and_write(
+    model_path: pathlib.Path, codegened_dir: pathlib.Path
+) -> Optional[str]:
     """Generate the code and write it to the pre-defined file."""
     # fmt: off
     symbol_table, _ = (
-        aas_core3_0_testgen.common.load_symbol_table_and_infer_constraints_for_schema()
+        aas_core3_0_testgen.common.load_symbol_table_and_infer_constraints_for_schema(
+            model_path=model_path
+        )
     )
     # fmt: on
 
@@ -549,7 +553,7 @@ def generate_and_write() -> Optional[str]:
 
     assert code is not None
 
-    path = _REPO_DIR / "aas_core3_0_testgen" / "codegened" / "wrapping.py"
+    path = codegened_dir / "wrapping.py"
     path.write_text(code + "\n", encoding="utf-8")
 
     return None
@@ -557,10 +561,21 @@ def generate_and_write() -> Optional[str]:
 
 def main() -> int:
     """Execute the main routine."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    _ = parser.parse_args()
+    repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
 
-    error = generate_and_write()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", help="path to the meta-model", required=True)
+    parser.add_argument(
+        "--codegened_dir",
+        help="path to the directory containing the generated code",
+        default=str(repo_dir / "aas_core3_0_testgen" / "codegened"),
+    )
+    args = parser.parse_args()
+
+    model_path = pathlib.Path(args.model_path)
+    codegened_dir = pathlib.Path(args.codegened_dir)
+
+    error = generate_and_write(model_path=model_path, codegened_dir=codegened_dir)
     if error is not None:
         print(error, file=sys.stderr)
         return 1

--- a/dev_scripts/fuzz_pattern_verification_functions.py
+++ b/dev_scripts/fuzz_pattern_verification_functions.py
@@ -1,4 +1,5 @@
 """Generate examples for all the pattern verification functions."""
+import argparse
 import pathlib
 import re
 import warnings
@@ -9,7 +10,6 @@ import hypothesis.errors
 import hypothesis.strategies
 from aas_core_codegen import intermediate
 import aas_core_codegen.run
-import aas_core_meta.v3
 
 warnings.filterwarnings(
     "ignore", category=hypothesis.errors.NonInteractiveExampleWarning
@@ -18,10 +18,13 @@ warnings.filterwarnings(
 
 def main() -> None:
     """Execute the main routine."""
-    (
-        symbol_table_atok,
-        error,
-    ) = aas_core_codegen.run.load_model(pathlib.Path(aas_core_meta.v3.__file__))
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", help="path to the meta-model", required=True)
+    args = parser.parse_args()
+
+    model_path = pathlib.Path(args.model_path)
+
+    symbol_table_atok, error = aas_core_codegen.run.load_model(model_path)
     if error is not None:
         raise RuntimeError(error)
     assert symbol_table_atok is not None

--- a/dev_scripts/update_to_aas_core_meta_and_codegen.py
+++ b/dev_scripts/update_to_aas_core_meta_and_codegen.py
@@ -17,6 +17,13 @@ import tempfile
 import time
 from typing import Optional, List, Callable, AnyStr, Sequence
 
+# NOTE (mristin):
+# We import the meta-model module here since we do not run this script to generate
+# the test data according to an arbitrary model, but to the concrete one as we pinned
+# it in ``setup.py``. We expect the files in ``test_data/`` directory to correspond to
+# exactly that meta-model version.
+import aas_core_meta.v3
+
 AAS_CORE_META_DEPENDENCY_RE = re.compile(
     r"aas-core-meta@git\+https://github.com/aas-core-works/aas-core-meta@([a-fA-F0-9]+)#egg=aas-core-meta"
 )
@@ -230,7 +237,14 @@ def _generate_code(our_repo: pathlib.Path) -> Optional[int]:
     # pylint: disable=consider-using-with
     calls = [
         lambda a_pth=pth, cwd=our_repo: subprocess.Popen(  # type: ignore
-            [sys.executable, str(a_pth)],
+            [
+                sys.executable,
+                str(a_pth),
+                "--model_path",
+                aas_core_meta.v3.__file__,
+                "--codegened_dir",
+                our_repo / "aas_core3_0_testgen" / "codegen",
+            ],
             cwd=str(cwd),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -346,7 +360,14 @@ def _generate_test_data(our_repo: pathlib.Path) -> Optional[int]:
     # pylint: disable=consider-using-with
     calls = [
         lambda a_pth=script, cwd=our_repo: subprocess.Popen(
-            [sys.executable, str(a_pth)],
+            [
+                sys.executable,
+                str(a_pth),
+                "--model_path",
+                aas_core_meta.v3.__file__,
+                "--test_data_dir",
+                test_data_dir,
+            ],
             cwd=str(cwd),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-icontract>=2.5.2,<3
-networkx==2.8
-typing-extensions==4.5.0

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,6 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
     long_description = fid.read()
 
-with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
-    install_requires = [line for line in fid.read().splitlines() if line.strip()]
-
 setup(
     name="aas-core3.0-testgen",
     version="0.0.1",
@@ -36,7 +33,12 @@ setup(
     license="License :: OSI Approved :: MIT License",
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
-    install_requires=install_requires,
+    install_requires=[
+        "icontract>=2.5.2,<3",
+        "networkx==2.8",
+        "typing-extensions==4.5.0",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@d06db62b#egg=aas-core-codegen",
+    ],
     # fmt: off
     extras_require={
         "dev": [
@@ -47,7 +49,6 @@ setup(
             "coverage>=6,<7",
             "twine",
             "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@6d5411b#egg=aas-core-meta",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@d06db62b#egg=aas-core-codegen",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",
             "jsonschema==4.17.3",
@@ -56,5 +57,5 @@ setup(
     # fmt: on
     py_modules=["aas_core3_0_testgen"],
     package_data={"aas_core3_0_testgen": ["py.typed"]},
-    data_files=[(".", ["LICENSE", "README.rst", "requirements.txt"])],
+    data_files=[(".", ["LICENSE", "README.rst"])],
 )

--- a/tests/test_generate_json.py
+++ b/tests/test_generate_json.py
@@ -8,6 +8,8 @@ import unittest
 from typing import List, Tuple, Optional
 
 import jsonschema
+import aas_core_meta.v3
+
 import aas_core3.jsonization
 import aas_core3.verification
 
@@ -19,7 +21,10 @@ class Test_against_recorded(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir_as_str:
             tmp_dir = pathlib.Path(tmp_dir_as_str)
 
-            aas_core3_0_testgen.generate_json.generate(test_data_dir=tmp_dir)
+            aas_core3_0_testgen.generate_json.generate(
+                model_path=pathlib.Path(aas_core_meta.v3.__file__),
+                test_data_dir=tmp_dir,
+            )
 
             repo_root = pathlib.Path(os.path.realpath(__file__)).parent.parent
             test_data_dir = repo_root / "test_data"

--- a/tests/test_generate_rdf.py
+++ b/tests/test_generate_rdf.py
@@ -6,6 +6,8 @@ import tempfile
 import unittest
 from typing import List, Tuple
 
+import aas_core_meta.v3
+
 import aas_core3_0_testgen.generate_rdf
 
 
@@ -14,7 +16,10 @@ class Test_against_recorded(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir_as_str:
             tmp_dir = pathlib.Path(tmp_dir_as_str)
 
-            aas_core3_0_testgen.generate_rdf.generate(test_data_dir=tmp_dir)
+            aas_core3_0_testgen.generate_rdf.generate(
+                model_path=pathlib.Path(aas_core_meta.v3.__file__),
+                test_data_dir=tmp_dir,
+            )
 
             repo_root = pathlib.Path(os.path.realpath(__file__)).parent.parent
             test_data_dir = repo_root / "test_data"

--- a/tests/test_generate_xml.py
+++ b/tests/test_generate_xml.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 import xml.etree.ElementTree
 
 import xmlschema
+import aas_core_meta.v3
 
 import aas_core3_0_testgen.generate_xml
 
@@ -17,7 +18,10 @@ class Test_against_recorded(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir_as_str:
             tmp_dir = pathlib.Path(tmp_dir_as_str)
 
-            aas_core3_0_testgen.generate_xml.generate(test_data_dir=tmp_dir)
+            aas_core3_0_testgen.generate_xml.generate(
+                model_path=pathlib.Path(aas_core_meta.v3.__file__),
+                test_data_dir=tmp_dir,
+            )
 
             repo_root = pathlib.Path(os.path.realpath(__file__)).parent.parent
             test_data_dir = repo_root / "test_data"


### PR DESCRIPTION
We change the generate scripts so that the model path as well as the target path of their artifacts need to be specified. This is necessary, so that the operators can run the scripts independent of their virtual environment. Previously, we relied on aas-core-meta and hard-coded the meta-model module, *i.e.*, `aas_core_meta.v3`. Now you can generate the test data for an arbitrary meta-model, which does not have to correspond to `aas_core_meta.v3`.

For example, when we generate test data for a provisional meta-model, we want to quickly see the results, without messing up the virtual environment for this application.