### PR TITLE
Pass absolute path to codegen warnings

### DIFF
--- a/dev_scripts/codegen/generate_abstract_fixing.py
+++ b/dev_scripts/codegen/generate_abstract_fixing.py
@@ -178,7 +178,7 @@ def _generate(
     symbol_table: intermediate.SymbolTable,
 ) -> Tuple[Optional[Stripped], Optional[str]]:
     """Generate the module."""
-    warning = dev_scripts.codegen.common.generate_warning(__file__)
+    warning = dev_scripts.codegen.common.generate_warning(os.path.realpath(__file__))
 
     blocks = [
         Stripped('"""Provide an abstract structure for fixing model instances."""'),

--- a/dev_scripts/codegen/generate_creation.py
+++ b/dev_scripts/codegen/generate_creation.py
@@ -1067,7 +1067,7 @@ def _generate(
     ],
 ) -> Tuple[Optional[Stripped], Optional[str]]:
     """Generate the creation module."""
-    warning = dev_scripts.codegen.common.generate_warning(__file__)
+    warning = dev_scripts.codegen.common.generate_warning(os.path.realpath(__file__))
 
     blocks = [
         Stripped('"""Create instances which satisfy the type constraints."""'),

--- a/dev_scripts/codegen/generate_preserialization.py
+++ b/dev_scripts/codegen/generate_preserialization.py
@@ -284,7 +284,7 @@ def _generate(
     symbol_table: intermediate.SymbolTable,
 ) -> Tuple[Optional[Stripped], Optional[str]]:
     """Generate the module."""
-    warning = dev_scripts.codegen.common.generate_warning(__file__)
+    warning = dev_scripts.codegen.common.generate_warning(os.path.realpath(__file__))
 
     blocks = [
         Stripped('"""Pre-serialize the instances for further modification."""'),

--- a/dev_scripts/codegen/generate_wrapping.py
+++ b/dev_scripts/codegen/generate_wrapping.py
@@ -413,7 +413,7 @@ def _generate(
         symbol_table=symbol_table
     )
 
-    warning = dev_scripts.codegen.common.generate_warning(__file__)
+    warning = dev_scripts.codegen.common.generate_warning(os.path.realpath(__file__))
 
     blocks = [
         Stripped(


### PR DESCRIPTION
Since we sometimes run generate scripts from the repository root, we need to pass the absolute path to the scripts in order to obtain script paths relative to the repository, not the current-working-directory.