### PR TITLE
Generate JSON cases with invalid model types

### DIFF
--- a/aas_core3/jsonization.py
+++ b/aas_core3/jsonization.py
@@ -1443,9 +1443,16 @@ def asset_administration_shell_from_jsonable(
 
     setter = _SetterForAssetAdministrationShell()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'AssetAdministrationShell':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'AssetAdministrationShell', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -2296,9 +2303,16 @@ def submodel_from_jsonable(
 
     setter = _SetterForSubmodel()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Submodel':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Submodel', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -3200,9 +3214,16 @@ def submodel_element_list_from_jsonable(
 
     setter = _SetterForSubmodelElementList()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'SubmodelElementList':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'SubmodelElementList', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -3578,9 +3599,16 @@ def submodel_element_collection_from_jsonable(
 
     setter = _SetterForSubmodelElementCollection()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'SubmodelElementCollection':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'SubmodelElementCollection', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -3988,9 +4016,16 @@ def property_from_jsonable(
 
     setter = _SetterForProperty()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Property':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Property', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -4378,9 +4413,16 @@ def multi_language_property_from_jsonable(
 
     setter = _SetterForMultiLanguageProperty()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'MultiLanguageProperty':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'MultiLanguageProperty', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -4753,9 +4795,16 @@ def range_from_jsonable(
 
     setter = _SetterForRange()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Range':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Range', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -5106,9 +5155,16 @@ def reference_element_from_jsonable(
 
     setter = _SetterForReferenceElement()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'ReferenceElement':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'ReferenceElement', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -5466,9 +5522,16 @@ def blob_from_jsonable(
 
     setter = _SetterForBlob()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Blob':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Blob', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -5832,9 +5895,16 @@ def file_from_jsonable(
 
     setter = _SetterForFile()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'File':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'File', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -6235,9 +6305,16 @@ def annotated_relationship_element_from_jsonable(
 
     setter = _SetterForAnnotatedRelationshipElement()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'AnnotatedRelationshipElement':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'AnnotatedRelationshipElement', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -6681,9 +6758,16 @@ def entity_from_jsonable(
 
     setter = _SetterForEntity()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Entity':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Entity', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -7435,9 +7519,16 @@ def basic_event_element_from_jsonable(
 
     setter = _SetterForBasicEventElement()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'BasicEventElement':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'BasicEventElement', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -7900,9 +7991,16 @@ def operation_from_jsonable(
 
     setter = _SetterForOperation()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Operation':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Operation', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -8307,9 +8405,16 @@ def capability_from_jsonable(
 
     setter = _SetterForCapability()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Capability':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Capability', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -8615,9 +8720,16 @@ def concept_description_from_jsonable(
 
     setter = _SetterForConceptDescription()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'ConceptDescription':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'ConceptDescription', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -10366,9 +10478,16 @@ def data_specification_iec_61360_from_jsonable(
 
     setter = _SetterForDataSpecificationIEC61360()
 
-    if 'modelType' not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'DataSpecificationIec61360':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'DataSpecificationIec61360', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():

--- a/aas_core3_0_testgen/generate_json.py
+++ b/aas_core3_0_testgen/generate_json.py
@@ -405,6 +405,32 @@ class _SerializerWithoutModelType(_Serializer):
         return jsonable
 
 
+class _SerializerWithInvalidModelType(_Serializer):
+    """Serialize a container to a JSON object with an invalid ``modelType``."""
+
+    def __init__(
+        self,
+        symbol_table: intermediate.SymbolTable,
+        target_instance: preserialization.Instance,
+    ) -> None:
+        """Initialize with the given values."""
+        self.target_instance = target_instance
+
+        super().__init__(symbol_table=symbol_table)
+
+    def serialize_instance(
+        self, instance: preserialization.Instance
+    ) -> OrderedDict[str, Any]:
+        """Convert the ``instance`` to a JSON-able data structure."""
+        jsonable = super().serialize_instance(instance)
+
+        if instance is self.target_instance:
+            assert "modelType" in jsonable
+            jsonable["modelType"] = "aCompletelyInvalidModelType"
+
+        return jsonable
+
+
 def to_json_path_segments(
     path: Sequence[Union[int, str]]
 ) -> List[Union[int, Identifier]]:
@@ -503,6 +529,55 @@ def _generate_unserializables_without_model_type(
             json.dump(jsonable, fid, indent=2, sort_keys=True)
 
 
+def _generate_unserializables_with_invalid_model_type(
+    symbol_table: intermediate.SymbolTable, test_data_dir: pathlib.Path
+) -> None:
+    """Generate the special cases where the required ``modelType`` is invalid."""
+    environment_cls = symbol_table.must_find_concrete_class(Identifier("Environment"))
+
+    for cls in symbol_table.concrete_classes:
+        if not cls.serialization.with_model_type:
+            continue
+
+        minimal_case = generation.generate_minimal_case(
+            cls=cls, environment_cls=environment_cls
+        )
+
+        serializer_with_invalid_model_type = _SerializerWithInvalidModelType(
+            symbol_table=symbol_table,
+            target_instance=minimal_case.preserialized_instance,
+        )
+
+        base_pth: pathlib.Path
+        if minimal_case.container_class is minimal_case.cls:
+            base_pth = pathlib.Path("Json/SelfContained")
+        else:
+            container_model_type = aas_core_codegen.naming.json_model_type(
+                minimal_case.container_class.name
+            )
+            base_pth = pathlib.Path(f"Json/ContainedIn{container_model_type}")
+
+        relative_pth = _generate_unexpected_path(
+            base_path=base_pth,
+            kind=KindOfNegative.UNSERIALIZABLE,
+            cause="InvalidModelType",
+            cls_name=aas_core_codegen.naming.json_model_type(minimal_case.cls.name),
+            relative_path=pathlib.Path("invalidModelType.json"),
+        )
+
+        jsonable = serializer_with_invalid_model_type.serialize_instance(
+            instance=minimal_case.preserialized_container
+        )
+
+        pth = test_data_dir / relative_pth
+
+        parent = pth.parent
+        parent.mkdir(parents=True, exist_ok=True)
+
+        with pth.open("wt") as fid:
+            json.dump(jsonable, fid, indent=2, sort_keys=True)
+
+
 def generate(model_path: pathlib.Path, test_data_dir: pathlib.Path) -> None:
     """Generate the JSON files."""
     (
@@ -533,6 +608,10 @@ def generate(model_path: pathlib.Path, test_data_dir: pathlib.Path) -> None:
     # JSON-specific, so we generate it outside the general :py:mod:`generation`
     # module.
     _generate_unserializables_without_model_type(
+        symbol_table=symbol_table, test_data_dir=test_data_dir
+    )
+
+    _generate_unserializables_with_invalid_model_type(
         symbol_table=symbol_table, test_data_dir=test_data_dir
     )
 

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json
@@ -1,0 +1,32 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json
@@ -1,0 +1,12 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "id": "something_142922d6",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "output",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "urn:another-example11:3679ef43"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "off"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json
@@ -1,0 +1,8 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_8ccad77f",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json
@@ -1,0 +1,30 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecificationContent": {
+            "modelType": "aCompletelyInvalidModelType",
+            "preferredName": [
+              {
+                "language": "i-enochian",
+                "text": "something_84b0b440"
+              },
+              {
+                "language": "en-GB",
+                "text": "Something random in English 5b15c20d"
+              }
+            ],
+            "value": "something_13759f45"
+          }
+        }
+      ],
+      "id": "something_142922d6",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "CoManagedEntity",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json
@@ -1,0 +1,32 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json
@@ -1,0 +1,8 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "typeValueListElement": "Entity"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
We generate JSON cases with invalid model types to test for two different behaviors:
1) Discrimination on invalid model type, and
2) De-serialization of a concrete class without descendants which has a
   mandatory ``modelType`` for backwards compatibility.

The SDK code had to be re-generated as the second behavior had not been implemented correctly. The re-generated SDK corresponds to [aas-core-codegen cd92d208].

[aas-core-codegen cd92d208]: https://github.com/aas-core-works/aas-core-codegen/commit/cd92d208