### PR TITLE
Update to aas-core-meta, codegen bd56058, a25c6436

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: 0f7345e1
+The revision of aas-core-codegen was: a25c6436
 """

--- a/aas_core3/verification.py
+++ b/aas_core3/verification.py
@@ -3426,7 +3426,7 @@ class _Transformer(
         if not (
             not (
                 (
-                    (that.value is not None)
+                    (that.type_value_list_element is not None)
                     and (
                         (
                             that.type_value_list_element == aas_types.AASSubmodelElements.PROPERTY
@@ -3438,9 +3438,14 @@ class _Transformer(
             or (
                 (
                     (that.value_type_list_element is not None)
-                    and properties_or_ranges_have_value_type(
-                        that.value,
-                        that.value_type_list_element
+                    and (
+                        (
+                            (that.value is None)
+                            or properties_or_ranges_have_value_type(
+                                that.value,
+                                that.value_type_list_element
+                            )
+                        )
                     )
                 )
             )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "icontract>=2.5.2,<3",
         "networkx==2.8",
         "typing-extensions==4.5.0",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@0f7345e1#egg=aas-core-codegen",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a25c6436#egg=aas-core-codegen",
     ],
     # fmt: off
     extras_require={
@@ -48,7 +48,7 @@ setup(
             "pydocstyle>=2.1.1<3",
             "coverage>=6,<7",
             "twine",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@31d6afd#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@bd56058#egg=aas-core-meta",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",
             "jsonschema==4.17.3",


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta bd56058], and
* [aas-core-codegen a25c6436].

Notably, we propagate the fix for AASd-109 where we change the invariant such that it checks for consistency among properties even when a value property is missing. This affects only the re-recording of the test data.

[aas-core-meta bd56058]: https://github.com/aas-core-works/aas-core-meta/commit/bd56058
[aas-core-codegen a25c6436]: https://github.com/aas-core-works/aas-core-codegen/commit/a25c6436