### PR TITLE
Update to aas-core-meta, codegen f9cbdb3, 6df5c9e8

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: a25c6436
+The revision of aas-core-codegen was: 6df5c9e8
 """

--- a/aas_core3/verification.py
+++ b/aas_core3/verification.py
@@ -3426,13 +3426,8 @@ class _Transformer(
         if not (
             not (
                 (
-                    (that.type_value_list_element is not None)
-                    and (
-                        (
-                            that.type_value_list_element == aas_types.AASSubmodelElements.PROPERTY
-                            or that.type_value_list_element == aas_types.AASSubmodelElements.RANGE
-                        )
-                    )
+                    that.type_value_list_element == aas_types.AASSubmodelElements.PROPERTY
+                    or that.type_value_list_element == aas_types.AASSubmodelElements.RANGE
                 )
             )
             or (

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "icontract>=2.5.2,<3",
         "networkx==2.8",
         "typing-extensions==4.5.0",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a25c6436#egg=aas-core-codegen",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@6df5c9e8#egg=aas-core-codegen",
     ],
     # fmt: off
     extras_require={
@@ -48,7 +48,7 @@ setup(
             "pydocstyle>=2.1.1<3",
             "coverage>=6,<7",
             "twine",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@bd56058#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@f9cbdb3#egg=aas-core-meta",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",
             "jsonschema==4.17.3",


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta f9cbdb3], and
* [aas-core-codegen 6df5c9e8].

Notably, we propagate the fix from aas-core-meta. We fix the invariant AASd-109 for type inference as we erroneously included a non-nullness check for a non-optional attribute (``type_value_list_element``).

[aas-core-meta f9cbdb3]: https://github.com/aas-core-works/aas-core-meta/commit/f9cbdb3
[aas-core-codegen 6df5c9e8]: https://github.com/aas-core-works/aas-core-codegen/commit/6df5c9e8